### PR TITLE
Fix broken link and update link according to previously linked site

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ However, it comes at the cost of usefulness, i.e., the amount of received packet
 ![](/img/usefulness_hops.png)
 
 ## Interactive simulator
-The interactive simulator uses the [Linux native application of Meshtastic](https://meshtastic.org/docs/software/linux-native), i.e. the real device software, while simulating some of the hardware interfaces, including the LoRa chip. Can also be used on a Windows or macOS host with Docker.
+The interactive simulator uses the [Linux native application of Meshtastic](https://meshtastic.org/docs/development/linux/), i.e. the real device software, while simulating some of the hardware interfaces, including the LoRa chip. Can also be used on a Windows or macOS host with Docker.
 
 See [this document](INTERACTIVE_SIM.md) for a usage guide. 
 
@@ -32,11 +32,10 @@ Furthermore, since the simulator has an 'oracle view' of the network, it allows 
 ![](/img/route_plot.png)
 
 ## License
-Part of the source code is based on the work in [1], which eventually stems from [2]. The LoRaSim library from [2] can be found [here](https://www.lancaster.ac.uk/scc/sites/lora/lorasim.html).
+Part of the source code is based on the work in [1], which eventually stems from [2]. The LoRaSim library from [2] can be found [here](https://mcbor.github.io/lorasim).
 
 This work is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/). 
 
 ## References
 1. [S. Spinsante, L. Gioacchini and L. Scalise, "A novel experimental-based tool for the design of LoRa networks," 2019 II Workshop on Metrology for Industry 4.0 and IoT (MetroInd4.0&IoT), 2019, pp. 317-322, doi: 10.1109/METROI4.2019.8792833.](https://ieeexplore.ieee.org/document/8792833)
 2. [Martin C. Bor, Utz Roedig, Thiemo Voigt, and Juan M. Alonso, "Do LoRa Low-Power Wide-Area Networks Scale?", In Proceedings of the 19th ACM International Conference on Modeling, Analysis and Simulation of Wireless and Mobile Systems (MSWiM '16), 2016. Association for Computing Machinery, New York, NY, USA, 59–67.](https://doi.org/10.1145/2988287.2989163)
-

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Furthermore, since the simulator has an 'oracle view' of the network, it allows 
 ![](/img/route_plot.png)
 
 ## License
-Part of the source code is based on the work in [1], which eventually stems from [2]. The LoRaSim library from [2] can be found [here](https://mcbor.github.io/lorasim).
+Part of the source code is based on the work in [1], which eventually stems from [2]. The LoRaSim library from [2] can be found [here](https://www.lancaster.ac.uk/scc/sites/lora/lorasim.html).
 
 This work is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/). 
 


### PR DESCRIPTION
Link to Mesthtastic documentation was broken.

Also, https://www.lancaster.ac.uk/scc/sites/lora/lorasim.html which was previously linked explicitly says that "This website has now been moved to [GitHub](https://mcbor.github.io/lorasim)."