### PR TITLE
Convert all uses of verboseprint to use python's logging module. Add …

### DIFF
--- a/batchSim.py
+++ b/batchSim.py
@@ -27,11 +27,6 @@ SHOW_GRAPH = False
 SAVE = True
 
 
-def verboseprint(*args, **kwargs):
-    if VERBOSE:
-        print(*args, **kwargs)
-
-
 #############################
 ####### BATCH PARAMS ########
 #############################
@@ -269,7 +264,7 @@ for rt_i, routerType in enumerate(routerTypes):
                 node = MeshNode(
                     routerTypeConf, nodes, env, bc_pipe, nodeId, routerTypeConf.PERIOD,
                     messages, packetsAtN, packets, delays, nodeConfig,
-                    messageSeq, verboseprint
+                    messageSeq
                 )
                 nodes.append(node)
                 if SHOW_GRAPH:

--- a/lib/mac.py
+++ b/lib/mac.py
@@ -1,22 +1,18 @@
+import logging
 import random
+
 from lib.phy import airtime, SLOT_TIME
 
+logger = logging.getLogger(__name__)
 
-VERBOSE = False
 CWmin = 2
 CWmax = 8
 PROCESSING_TIME_MSEC = 4500
 
 
-def verboseprint(*args, **kwargs):
-    if VERBOSE:
-        print(*args, **kwargs)
-
-
 def set_transmit_delay(node, packet):  # from RadioLibInterface::setTransmitDelay
     for p in reversed(node.packetsAtN[node.nodeid]):
         if p.seq == packet.seq and p.rssiAtN[node.nodeid] != 0 and p.receivedAtN[node.nodeid] is True:
-            # verboseprint(round(self.env.now, 3), 'Pick delay with RSSI of node', self.nodeid, 'is', p.rssiAtN[self.nodeid])
             return get_tx_delay_msec_weighted(node, p.rssiAtN[node.nodeid])  # weighted waiting based on RSSI
     return get_tx_delay_msec(node)
 
@@ -26,10 +22,10 @@ def get_tx_delay_msec_weighted(node, rssi):  # from RadioInterface::getTxDelayMs
     SNR_MIN = -20
     SNR_MAX = 15
     if snr < SNR_MIN:
-        verboseprint(f'Minimum SNR at RSSI of {rssi} dBm')
+        logger.debug(f'Minimum SNR at RSSI of {rssi} dBm')
         snr = SNR_MIN
     if snr > SNR_MAX:
-        verboseprint(f'Maximum SNR at RSSI of {rssi} dBm')
+        logger.debug(f'Maximum SNR at RSSI of {rssi} dBm')
         snr = SNR_MAX
 
     CWsize = int((snr - SNR_MIN) * (CWmax - CWmin) / (SNR_MAX - SNR_MIN) + CWmin)
@@ -37,7 +33,7 @@ def get_tx_delay_msec_weighted(node, rssi):  # from RadioInterface::getTxDelayMs
         CW = random.randint(0, 2 * CWsize - 1)
     else:
         CW = random.randint(0, 2 ** CWsize - 1)
-    verboseprint(f'Node {node.nodeid} has CW size {CWsize} and picked CW {CW}')
+    logger.debug(f'Node {node.nodeid} has CW size {CWsize} and picked CW {CW}')
     return CW * SLOT_TIME
 
 
@@ -45,7 +41,7 @@ def get_tx_delay_msec(node):  # from RadioInterface::getTxDelayMsec
     channelUtil = node.airUtilization / node.env.now * 100
     CWsize = int(channelUtil * (CWmax - CWmin) / 100 + CWmin)
     CW = random.randint(0, 2 ** CWsize - 1)
-    verboseprint(f'Current channel utilization is {channelUtil}, so picked CW {CW}')
+    logger.debug(f'Current channel utilization is {channelUtil}, so picked CW {CW}')
     return CW * SLOT_TIME
 
 

--- a/lib/packet.py
+++ b/lib/packet.py
@@ -5,9 +5,8 @@ NODENUM_BROADCAST = 0xFFFFFFFF
 
 
 class MeshPacket:
-	def __init__(self, conf, nodes, origTxNodeId, destId, txNodeId, plen, seq, genTime, wantAck, isAck, requestId, now, verboseprint):
+	def __init__(self, conf, nodes, origTxNodeId, destId, txNodeId, plen, seq, genTime, wantAck, isAck, requestId, now):
 		self.conf = conf
-		self.verboseprint = verboseprint
 		self.origTxNodeId = origTxNodeId
 		self.destId = destId
 		self.txNodeId = txNodeId

--- a/lib/phy.py
+++ b/lib/phy.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import random
 
@@ -5,12 +6,9 @@ from lib.config import Config
 
 conf = Config()
 
-VERBOSE = False
+logger = logging.getLogger(__name__)
 
 
-def verboseprint(*args, **kwargs):
-    if VERBOSE:
-        print(*args, **kwargs)
 
 
 #                           CAD duration   +     airPropagationTime+TxRxTurnaround+MACprocessing
@@ -28,7 +26,7 @@ def check_collision(conf, env, packet, rx_nodeId, packetsAtN):
         for other in packetsAtN[rx_nodeId]:
             if frequency_collision(packet, other) and sf_collision(packet, other):
                 if timing_collision(conf, env, packet, other):
-                    verboseprint(f'Packet nr. {packet.seq} from {packet.txNodeId} and packet nr. {other.seq} from {other.txNodeId} will collide!')
+                    logger.debug(f'Packet nr. {packet.seq} from {packet.txNodeId} and packet nr. {other.seq} from {other.txNodeId} will collide!')
                     c = power_collision(packet, other, rx_nodeId)
                     # mark all the collided packets
                     for p in c:


### PR DESCRIPTION
…--verbose flag

This makes it easier to do debug logging (and more) throughout the code, since we can easily have different log levels and automatically get log messages from modules. We do set the default to INFO and only enable DEBUG on our own code if the -v/--verbose flag is passed to loraMesh.py, so that we don't see DEBUG messages from modules like PIL or matplotlib.

This lets us noticeably speed up loraMesh.py by disabling debugging output.