### PR TITLE
Refactor/#55 add simulation meta object

### DIFF
--- a/batchSim.py
+++ b/batchSim.py
@@ -279,7 +279,7 @@ for rt_i, routerType in enumerate(routerTypes):
             nodeUsefulness[rep] = results['usefulness'] * 100
 
             meanDelay[rep] = results['meanDelay']
-            meanTxAirUtilization[rep] = results['txAirUtilization']
+            meanTxAirUtilization[rep] = results['txAirUtilizationRate']
 
             if routerTypeConf.MODEL_ASYMMETRIC_LINKS:
                 # actually percentages, not rates

--- a/batchSim.py
+++ b/batchSim.py
@@ -17,8 +17,9 @@ import matplotlib.pyplot as plt
 from lib.config import Config
 from lib.common import find_random_position, setup_asymmetric_links
 from lib.discrete_event import BroadcastPipe, sim_report
+from lib.discrete_event_sim import DiscreteEventSim
 from lib.gui import Graph, run_graph_updates
-from lib.node import MeshNode, NodeConfig
+from lib.node import NodeConfig
 from lib.point import Point
 
 # TODO - There should really be two separate concepts here, a STATE and a CONFIG
@@ -229,46 +230,45 @@ for rt_i, routerType in enumerate(routerTypes):
             effectiveSeed = rt_i * 10000 + rep
             routerTypeConf.SEED = effectiveSeed
             random.seed(effectiveSeed)
-            env = simpy.Environment()
-            bc_pipe = BroadcastPipe(env)
-
-            # Start the progress-logging process
-            env.process(simulation_progress(env, rep, repetitions, routerTypeConf.SIMTIME))
 
             # Retrieve the pre-generated positions for this (nrNodes, rep)
             coords = positions_cache[(nrNodes, rep)]
 
-            nodes = []
-            messages = []
-            packets = []
-            delays = []
-            packetsAtN = [[] for _ in range(routerTypeConf.NR_NODES)]
-            messageSeq = {"val": 0}
+            node_configs = []
 
-            if SHOW_GRAPH:
-                graph = Graph(routerTypeConf)
             for nodeId in range(routerTypeConf.NR_NODES):
                 x, y = coords[nodeId]
 
                 # We create a NodeConfig object so that MeshNode will use that
                 nodeConfig = NodeConfig(nodeId, Point(x, y, routerTypeConf.HM), antenna_gain=routerTypeConf.GL, hop_limit=routerTypeConf.hopLimit)
+                node_configs.append(nodeConfig)
 
-                node = MeshNode(
-                    routerTypeConf, nodes, env, bc_pipe, routerTypeConf.PERIOD,
-                    messages, packetsAtN, packets, delays, nodeConfig,
-                    messageSeq
-                )
-                nodes.append(node)
-                if SHOW_GRAPH:
-                    graph.add_node(node)
+            if SHOW_GRAPH:
+                graph = Graph(routerTypeConf)
+                sim = DiscreteEventSim(routerTypeConf, node_configs, graph)
+            else:
+                sim = DiscreteEventSim(routerTypeConf, node_configs)
 
-            if routerTypeConf.MOVEMENT_ENABLED and SHOW_GRAPH:
-                env.process(run_graph_updates(env, graph, nodes))
-
-            totalPairs, symmetricLinks, asymmetricLinks, noLinks = setup_asymmetric_links(routerTypeConf, nodes)
+            # Start the progress-logging process
+            env = sim.get_env()
+            env.process(simulation_progress(env, rep, repetitions, routerTypeConf.SIMTIME))
 
             # Start simulation
-            env.run(until=routerTypeConf.SIMTIME)
+            sim.run_simulation()
+
+            results = sim.get_results()
+
+            # TODO: some of these probably unused
+            packets = results["packets"]
+            packetsAtN = results["packetsAtN"]
+            messageSeq = results["messageSeq"]
+            messages = results["messages"]
+            delays = results["delays"]
+            totalPairs = results["totalPairs"]
+            symmetricLinks = results["symmetricLinks"]
+            asymmetricLinks = results["asymmetricLinks"]
+            noLinks = results["noLinks"]
+            nodes = results["nodes"]
 
             # Calculate stats
             nrCollisions = sum([1 for pkt in packets for n in nodes if pkt.collidedAtN[n.nodeid]])

--- a/batchSim.py
+++ b/batchSim.py
@@ -267,34 +267,25 @@ for rt_i, routerType in enumerate(routerTypes):
             noLinks = results["noLinks"]
             nodes = results["nodes"]
 
-            # Calculate stats
-            nrCollisions = sum([1 for pkt in packets for n in nodes if pkt.collidedAtN[n.nodeid]])
-            nrSensed = sum([1 for pkt in packets for n in nodes if pkt.sensedByN[n.nodeid]])
-            nrReceived = sum([1 for pkt in packets for n in nodes if pkt.receivedAtN[n.nodeid]])
-            nrUseful = sum([n.usefulPackets for n in nodes])
+            # collect second-order results from finalized results
+            nrCollisions = results['nrCollisions']
+            nrSensed = results['nrSensed']
+            nrReceived = results['nrReceived']
+            nrUseful = results['nrUseful']
 
-            if nrSensed != 0:
-                collisionRate[rep] = float(nrCollisions) / nrSensed * 100
-            else:
-                collisionRate[rep] = np.NaN
+            # actually percentages, not rates
+            collisionRate[rep] = results['collisionRate'] * 100
+            nodeReach[rep] = results['nodeReach'] * 100
+            nodeUsefulness[rep] = results['usefulness'] * 100
 
-            if messageSeq["val"] != 0:
-                nodeReach[rep] = nrUseful / (messageSeq["val"] * (routerTypeConf.NR_NODES - 1)) * 100
-            else:
-                nodeReach[rep] = np.NaN
-
-            if nrReceived != 0:
-                nodeUsefulness[rep] = nrUseful / nrReceived * 100
-            else:
-                nodeUsefulness[rep] = np.NaN
-
-            meanDelay[rep] = np.nanmean(delays)
-            meanTxAirUtilization[rep] = sum([n.txAirUtilization for n in nodes]) / routerTypeConf.NR_NODES
+            meanDelay[rep] = results['meanDelay']
+            meanTxAirUtilization[rep] = results['txAirUtilization']
 
             if routerTypeConf.MODEL_ASYMMETRIC_LINKS:
-                asymmetricLinkRate[rep] = round(asymmetricLinks / totalPairs * 100, 2)
-                symmetricLinkRate[rep] = round(symmetricLinks / totalPairs * 100, 2)
-                noLinkRate[rep] = round(noLinks / totalPairs * 100, 2)
+                # actually percentages, not rates
+                asymmetricLinkRate[rep] = round(results['asymmetricLinkRate'] * 100, 2)
+                symmetricLinkRate[rep] = round(results['symmetricLinkRate'] * 100, 2)
+                noLinkRate[rep] = round(results['noLinkRate'] * 100, 2)
 
         # After finishing all repetitions for this nrNodes, compute means/stdevs
         collisions.append(np.nanmean(collisionRate))

--- a/batchSim.py
+++ b/batchSim.py
@@ -258,11 +258,8 @@ for rt_i, routerType in enumerate(routerTypes):
 
             results = sim.get_results()
 
-            # TODO: some of these probably unused
             packets = results["packets"]
-            packetsAtN = results["packetsAtN"]
             messageSeq = results["messageSeq"]
-            messages = results["messages"]
             delays = results["delays"]
             totalPairs = results["totalPairs"]
             symmetricLinks = results["symmetricLinks"]

--- a/lib/common.py
+++ b/lib/common.py
@@ -6,44 +6,18 @@ import numpy as np
 from lib import phy
 from lib.point import Point
 
-def find_random_position(conf, nodes):
-    foundMin = True
-    foundMax = False
-    tries = 0
-    position = None
-    while not (foundMin and foundMax):
-        a = random.random()
-        b = random.random()
-        posx = a*conf.XSIZE+conf.OX-conf.XSIZE/2
-        posy = b*conf.YSIZE+conf.OY-conf.YSIZE/2
-        pos_candidate = Point(posx, posy, conf.HM)
-        if len(nodes) > 0:
-            for n in nodes:
-                dist = n.position.euclidean_distance(pos_candidate)
-                if dist < conf.MINDIST:
-                    foundMin = False
-                    break
-                pathLoss = phy.estimate_path_loss(conf, dist, conf.FREQ)
-                rssi = conf.PTX + 2*conf.GL - pathLoss
-                # At least one node should be able to reach it
-                if rssi >= conf.current_preset["sensitivity"]:
-                    foundMax = True
-            if foundMin and foundMax:
-                position = pos_candidate
-        else:
-            position = pos_candidate
-            foundMin = True
-            foundMax = True
-        tries += 1
-        if tries > 1000:
-            print('Could not find a location to place the node. Try increasing XSIZE/YSIZE or decreasing MINDIST.')
-            break
-    return max(-conf.XSIZE/2, position.x), max(-conf.YSIZE/2, position.y)
+def find_random_position(conf, node_configs) -> (float, float):
+    """Given a simulation config and list of existing node configs/nodes, find a
+    randomly chosen position for the next node such that it is within the
+    simulation bounds, within radio range of at least one existing node, and
+    not within the minimum distance of any existing node.
 
-def find_random_position_nodeconf(conf, node_configs):
-    """Ugly hack to have a version of find_random_position that only
-    requires node configs and NOT full node objects, so we can get new
-    functionality working and save some refactoring for later.
+    Arguments:
+    conf -- Config object defining simulation
+    node_configs -- list of NodeConfig objects, or node objects, defining pre-existing nodes
+
+    Returns:
+    (x, y) - x and y coordinates of location for next node
     """
     foundMin = True
     foundMax = False

--- a/lib/common.py
+++ b/lib/common.py
@@ -40,6 +40,44 @@ def find_random_position(conf, nodes):
             break
     return max(-conf.XSIZE/2, position.x), max(-conf.YSIZE/2, position.y)
 
+def find_random_position_nodeconf(conf, node_configs):
+    """Ugly hack to have a version of find_random_position that only
+    requires node configs and NOT full node objects, so we can get new
+    functionality working and save some refactoring for later.
+    """
+    foundMin = True
+    foundMax = False
+    tries = 0
+    position = None
+    while not (foundMin and foundMax):
+        a = random.random()
+        b = random.random()
+        posx = a*conf.XSIZE+conf.OX-conf.XSIZE/2
+        posy = b*conf.YSIZE+conf.OY-conf.YSIZE/2
+        pos_candidate = Point(posx, posy, conf.HM)
+        if len(node_configs) > 0:
+            for n in node_configs:
+                dist = n.position.euclidean_distance(pos_candidate)
+                if dist < conf.MINDIST:
+                    foundMin = False
+                    break
+                pathLoss = phy.estimate_path_loss(conf, dist, conf.FREQ)
+                rssi = conf.PTX + 2*conf.GL - pathLoss
+                # At least one node should be able to reach it
+                if rssi >= conf.current_preset["sensitivity"]:
+                    foundMax = True
+            if foundMin and foundMax:
+                position = pos_candidate
+        else:
+            position = pos_candidate
+            foundMin = True
+            foundMax = True
+        tries += 1
+        if tries > 1000:
+            print('Could not find a location to place the node. Try increasing XSIZE/YSIZE or decreasing MINDIST.')
+            break
+    return max(-conf.XSIZE/2, position.x), max(-conf.YSIZE/2, position.y)
+
 # TODO: once lib/interactive no longer uses this, we can remove this and put all distance calculation in Point
 def calc_dist(x0, x1, y0, y1, z0=0, z1=0):
     return np.sqrt(((abs(x0-x1))**2)+((abs(y0-y1))**2)+((abs(z0-z1)**2)))

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -96,11 +96,10 @@ class SimulationResults:
         self.results["meanDelay"] = np.nanmean(self.results["delays"])
 
         # various division-by-0 guarded calculations
-        # TODO: rename, rate. Average tx utilization over all nodes, per ms, for the full sim.
         if conf.NR_NODES != 0 and conf.SIMTIME != 0:
-            self.results["txAirUtilization"] = sum([n.txAirUtilization for n in nodes])/conf.NR_NODES/conf.SIMTIME
+            self.results["txAirUtilizationRate"] = sum([n.txAirUtilization for n in nodes])/conf.NR_NODES/conf.SIMTIME
         else:
-            self.results["txAirUtilization"] = np.nan
+            self.results["txAirUtilizationRate"] = np.nan
 
         if self.results["nrSensed"] != 0:
             self.results["collisionRate"] = self.results["nrCollisions"]/self.results["nrSensed"]

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -32,7 +32,13 @@ class SimulationDataTracking:
     """Class to hold data used to monitor a simulation which has no
     impact on the state or progress of the simulation
     """
-    pass
+    def __init__(self):
+        self.messages = []
+        self.delays = []
+        self.totalPairs = 0
+        self.symmetricLinks = 0
+        self.asymmetricLinks = 0
+        self.noLinks = 0
 
 class SimulationResults:
     """Class to hold simulation result data. Any interesting or relevant
@@ -81,12 +87,7 @@ class DiscreteEventSim:
         self.nodes = []
 
         # stats & data tracking
-        self.messages = []
-        self.delays = []
-        self.totalPairs = 0
-        self.symmetricLinks = 0
-        self.asymmetricLinks = 0
-        self.noLinks = 0
+        self.data_tracking = SimulationDataTracking()
 
         # note: we allow user to specify if graphing will happen or not
         self.graph = graph
@@ -101,10 +102,10 @@ class DiscreteEventSim:
                 self.env,
                 self.mutated_state.bc_pipe,
                 self.conf.PERIOD,
-                self.messages,
+                self.data_tracking.messages,
                 self.mutated_state.packetsAtN,
                 self.mutated_state.packets,
-                self.delays,
+                self.data_tracking.delays,
                 self.mutated_state.messageSeq
             )
         else:
@@ -115,10 +116,10 @@ class DiscreteEventSim:
                     self.env,
                     self.mutated_state.bc_pipe,
                     self.conf.PERIOD,
-                    self.messages,
+                    self.data_tracking.messages,
                     self.mutated_state.packetsAtN,
                     self.mutated_state.packets,
-                    self.delays,
+                    self.data_tracking.delays,
                     cfg,
                     self.mutated_state.messageSeq
                 )
@@ -129,7 +130,7 @@ class DiscreteEventSim:
                 self.graph.add_node(n)
 
         # setup that requires having nodes
-        self.totalPairs, self.symmetricLinks, self.asymmetricLinks, self.noLinks = setup_asymmetric_links(self.conf, self.nodes)
+        self.data_tracking.totalPairs, self.data_tracking.symmetricLinks, self.data_tracking.asymmetricLinks, self.data_tracking.noLinks = setup_asymmetric_links(self.conf, self.nodes)
 
         if self.graph is not None and self.conf.MOVEMENT_ENABLED:
             # NOTE: this does not run under test, since we skip creating a GUI
@@ -155,12 +156,12 @@ class DiscreteEventSim:
             "packets": self.mutated_state.packets,
             "packetsAtN": self.mutated_state.packetsAtN,
             "messageSeq": self.mutated_state.messageSeq,
-            "messages": self.messages,
-            "delays": self.delays,
-            "totalPairs": self.totalPairs,
-            "symmetricLinks": self.symmetricLinks,
-            "asymmetricLinks": self.asymmetricLinks,
-            "noLinks": self.noLinks,
+            "messages": self.data_tracking.messages,
+            "delays": self.data_tracking.delays,
+            "totalPairs": self.data_tracking.totalPairs,
+            "symmetricLinks": self.data_tracking.symmetricLinks,
+            "asymmetricLinks": self.data_tracking.asymmetricLinks,
+            "noLinks": self.data_tracking.noLinks,
             "nodes": self.nodes,
         }
         # TODO: add some universally useful result calculations, like the

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -1,0 +1,106 @@
+import logging
+
+from simpy import Environment as SimpyEnvironment
+
+from lib.common import setup_asymmetric_links
+from lib.config import Config
+from lib.discrete_event import BroadcastPipe
+from lib.gui import Graph, run_graph_updates
+from lib.node import MeshNode, NodeConfig, generate_node_list
+
+logger = logging.getLogger(__name__)
+
+class SimulationResults:
+    """Class to hold simulation result data. Any interesting or relevant
+    statistic/data from a simulation should wind up in here. Reporting
+    functions can take this object and present a report to the user however
+    makes sense.
+
+    Just a glorified dictionary honestly.
+    """
+    def __init__(self, results: dict):
+        self.results = results.copy() # only a shallow copy
+
+class DiscreteEventSim:
+    """Class for a full Discrete Event Simulation. Contains
+    simulation config, all necessary state, and sim plumbing.
+    """
+
+    def __init__(self, env: SimpyEnvironment, config: Config, node_configs: [NodeConfig] = [], graph: Graph | None = None):
+        """Constructor.
+
+        Arguments:
+        env -- SimPy Environment object to use
+        config -- Config object defining global constants for simulation.
+        node_configs -- Output of parse_params. List of node configurations. Default [].
+        graph -- Optional Graph object for GUI. If provided GUI will be used. Default None, for no GUI.
+        """
+        # InteractiveSim takes argparse output as the single parameter here, tightly
+        # coupling CLI arguments to this class. This works but try with a looser
+        # coupling first, so that parameters can be translated/normalized first,
+        # and then only relevant ones passed to the constructor.
+
+        # set state from parameters
+        self.env = env
+        self.conf = config
+        self.node_configs = node_configs
+        self.nodes = []
+
+        # internal state
+        self.bc_pipe = BroadcastPipe(env)
+        self.packets = []
+        self.packetsAtN = [[] for _ in range(self.conf.NR_NODES)]
+        self.messageSeq = {"val": 0}
+
+        # stats & data tracking
+        self.messages = []
+        self.delays = []
+        self.totalPairs = 0
+        self.symmetricLinks = 0
+        self.asymmetricLinks = 0
+        self.noLinks = 0
+
+        # note: we allow user to specify if graphing will happen or not
+        self.graph = graph
+
+        # create nodes once we have the various things they have to be wired into
+        if self.node_configs == [] or self.node_configs[0] is None:
+            # default case: no nodes, or default unspecified nodes.
+            # generate a default scenario
+            self.nodes = generate_node_list(self.conf, self.node_configs, self.env, self.bc_pipe, self.conf.PERIOD, self.messages, self.packetsAtN, self.packets, self.delays, self.messageSeq)
+        else:
+            # node configs provided, create nodes with them
+            for cfg in self.node_configs:
+                n = MeshNode(self.conf, self.nodes, self.env, self.bc_pipe, self.conf.PERIOD, self.messages, self.packetsAtN, self.packets, self.delays, cfg, self.messageSeq)
+                self.nodes.append(n)
+
+        if self.graph is not None:
+            for n in self.nodes:
+                self.graph.add_node(n)
+
+        # setup that requires having nodes
+        self.totalPairs, self.symmetricLinks, self.asymmetricLinks, self.noLinks = setup_asymmetric_links(self.conf, self.nodes)
+
+        if self.graph is not None and self.conf.MOVEMENT_ENABLED:
+            env.process(run_graph_updates(self.env, self.graph, self.nodes, self.conf.ONE_MIN_INTERVAL))
+        self.conf.update_router_dependencies()
+
+    def run_simulation(self):
+        self.env.run(until=self.conf.SIMTIME)
+
+    # just return a dictionary for now, refactor into an object later
+    def get_results(self) -> {}:
+        results = {
+            "packets": self.packets,
+            "packetsAtN": self.packetsAtN,
+            "messageSeq": self.messageSeq,
+            "messages": self.messages,
+            "delays": self.delays,
+            "totalPairs": self.totalPairs,
+            "symmetricLinks": self.symmetricLinks,
+            "asymmetricLinks": self.asymmetricLinks,
+            "noLinks": self.noLinks,
+            "nodes": self.nodes,
+        }
+        return results
+

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -136,7 +136,7 @@ class DiscreteEventSim:
     simulation config, all necessary state, and sim plumbing.
     """
 
-    def __init__(self, conf: Config, node_configs: [NodeConfig] = [], graph: Graph | None = None):
+    def __init__(self, conf: Config, node_configs: [NodeConfig], graph: Graph | None = None):
         """Constructor.
 
         Arguments:
@@ -162,14 +162,10 @@ class DiscreteEventSim:
         # note: we allow user to specify if graphing will happen or not
         self.graph = graph
 
-        # TODO: only use provided node configurations, don't generate our own.
-        # create nodes once we have the various things they have to be wired into
-        if self.node_configs == [] or self.node_configs[0] is None:
-            # default case: no nodes, or default unspecified nodes.
-            # generate a default scenario
-            self.nodes = default_generate_node_list(
-                self.conf,
-                self.node_configs,
+        # node configs provided, create nodes with them
+        for cfg in self.node_configs:
+            n = MeshNode(self.conf,
+                self.nodes,
                 self.env,
                 self.mutated_state.bc_pipe,
                 self.conf.PERIOD,
@@ -177,24 +173,10 @@ class DiscreteEventSim:
                 self.mutated_state.packetsAtN,
                 self.mutated_state.packets,
                 self.data_tracking.delays,
+                cfg,
                 self.mutated_state.messageSeq
             )
-        else:
-            # node configs provided, create nodes with them
-            for cfg in self.node_configs:
-                n = MeshNode(self.conf,
-                    self.nodes,
-                    self.env,
-                    self.mutated_state.bc_pipe,
-                    self.conf.PERIOD,
-                    self.data_tracking.messages,
-                    self.mutated_state.packetsAtN,
-                    self.mutated_state.packets,
-                    self.data_tracking.delays,
-                    cfg,
-                    self.mutated_state.messageSeq
-                )
-                self.nodes.append(n)
+            self.nodes.append(n)
 
         if self.graph is not None:
             for n in self.nodes:

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -2,12 +2,14 @@ import logging
 
 # probably not necessary, but "Environment" seemed too generic to me
 from simpy import Environment as SimpyEnvironment
+import numpy as np
 
 from lib.common import setup_asymmetric_links
 from lib.config import Config
 from lib.discrete_event import BroadcastPipe
 from lib.gui import Graph, run_graph_updates
 from lib.node import MeshNode, NodeConfig, generate_node_list
+from lib.packet import MeshPacket
 
 logger = logging.getLogger(__name__)
 
@@ -46,16 +48,89 @@ class SimulationResults:
     functions can take this object and present a report to the user however
     makes sense.
 
-    Just a glorified dictionary honestly.
+    Mostly a dictionary with extra features.
     """
     def __init__(self, results: dict):
+        """Constructor. Start off results with first-order results.
+
+        Arguments:
+        results -- dictionary of first-order results from simulation. MANY keys are assumed to exist!
+        """
         self.results = results.copy() # only a shallow copy
 
-    def finalize(self):
-        """Once simulation is finished, calculate any second-order
-        data that is generally useful, such as averages.
+    def __getitem__(self, subscript: str):
+        """Implement subscript access to support `results_object['datapoint']`.
+        Very thin wrapper to index into interior dictionary, allowing Exceptions
+        to bubble up to the caller.
         """
-        pass
+        return self.results[subscript]
+
+    def finalize(self, conf: Config, nodes: [MeshNode], packets: [MeshPacket]):
+        """Once simulation is finished, calculate any second-order
+        data that is generally useful, such as averages. This requires some extra
+        state-related info.
+
+        All calculated rates are left as the 'raw' ratio. As in, 50% is 0.5,
+        100% is 1, etc. If you want percentages you should scale & round the
+        rate however you prefer.
+
+        Arguments:
+        conf -- Config object. Simulation config.
+        nodes -- list of nodes from simulation.
+        packets -- list of packets sent during simulation.
+        """
+        # replicate result enrichment/calculation from loraMesh.py and batchSim.py
+        sent = len(self.results["packets"])
+        if conf.DMs:
+            self.results["potentialReceivers"] = sent
+        else:
+            self.results["potentialReceivers"] = sent * (conf.NR_NODES - 1)
+        self.results["sent"] = sent
+
+        # TODO: inefficient. Have nodes keep counters for these and just collect them
+        self.results["nrCollisions"] = sum([1 for p in packets for n in nodes if p.collidedAtN[n.nodeid] is True])
+        self.results["nrSensed"] = sum([1 for p in packets for n in nodes if p.sensedByN[n.nodeid] is True])
+        self.results["nrReceived"] = sum([1 for p in packets for n in nodes if p.receivedAtN[n.nodeid] is True])
+        self.results["nrUseful"] = sum([n.usefulPackets for n in nodes])
+
+        self.results["meanDelay"] = np.nanmean(self.results["delays"])
+
+        # various division-by-0 guarded calculations
+        # TODO: rename, rate. Average tx utilization over all nodes, per ms, for the full sim.
+        if conf.NR_NODES != 0 and conf.SIMTIME != 0:
+            self.results["txAirUtilization"] = sum([n.txAirUtilization for n in nodes])/conf.NR_NODES/conf.SIMTIME
+        else:
+            self.results["txAirUtilization"] = np.nan
+
+        if self.results["nrSensed"] != 0:
+            self.results["collisionRate"] = self.results["nrCollisions"]/self.results["nrSensed"]
+        else:
+            self.results["collisionRate"] = np.nan
+
+        if self.results["messageSeq"]["val"] != 0 and conf.NR_NODES - 1 != 0:
+            self.results["nodeReach"] = self.results["nrUseful"]/(self.results["messageSeq"]["val"]*(conf.NR_NODES-1))
+        else:
+            self.results["nodeReach"] = np.nan
+
+        if self.results["nrReceived"] != 0:
+            usefulness = self.results["nrUseful"]/self.results["nrReceived"]  # nr of packets that delivered to a packet to a new receiver out of all packets sent
+            self.results["usefulness"] = usefulness
+        else:
+            self.results["usefulness"] = np.nan
+
+        self.results["delayDropped"] = sum(n.droppedByDelay for n in nodes)
+
+        if conf.MODEL_ASYMMETRIC_LINKS and self.results["totalPairs"] != 0:
+            asymmetricLinkRate = self.results["asymmetricLinks"] / self.results["totalPairs"]
+            symmetricLinkRate = self.results["symmetricLinks"] / self.results["totalPairs"]
+            noLinkRate = self.results["noLinks"] / self.results["totalPairs"]
+            self.results["asymmetricLinkRate"] = asymmetricLinkRate
+            self.results["symmetricLinkRate"] = symmetricLinkRate
+            self.results["noLinkRate"] = noLinkRate
+
+        if conf.MOVEMENT_ENABLED:
+            self.results["movingNodes"] = sum([1 for n in nodes if n.isMoving is True])
+            self.results["gpsEnabled"] = sum([1 for n in nodes if n.gpsEnabled is True])
 
 class DiscreteEventSim:
     """Class for a full Discrete Event Simulation. Contains
@@ -149,10 +224,10 @@ class DiscreteEventSim:
         """
         return self.env
 
-    # just return a dictionary for now, refactor into an object later
-    def get_results(self) -> {}:
+    def get_results(self) -> SimulationResults:
+        # TODO: is it possible to add a check that the sim has finished running?
         # first-order stats/data collection
-        results = {
+        first_order_results = {
             "packets": self.mutated_state.packets,
             "packetsAtN": self.mutated_state.packetsAtN,
             "messageSeq": self.mutated_state.messageSeq,
@@ -164,6 +239,9 @@ class DiscreteEventSim:
             "noLinks": self.data_tracking.noLinks,
             "nodes": self.nodes,
         }
+        results = SimulationResults(first_order_results)
+        results.finalize(self.conf, self.nodes, self.mutated_state.packets)
+
         # TODO: add some universally useful result calculations, like the
         # ones common between loraMesh.py and batchSim.py
         return results

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -95,11 +95,33 @@ class DiscreteEventSim:
         if self.node_configs == [] or self.node_configs[0] is None:
             # default case: no nodes, or default unspecified nodes.
             # generate a default scenario
-            self.nodes = generate_node_list(self.conf, self.node_configs, self.env, self.mutated_state.bc_pipe, self.conf.PERIOD, self.messages, self.mutated_state.packetsAtN, self.mutated_state.packets, self.delays, self.mutated_state.messageSeq)
+            self.nodes = generate_node_list(
+                self.conf,
+                self.node_configs,
+                self.env,
+                self.mutated_state.bc_pipe,
+                self.conf.PERIOD,
+                self.messages,
+                self.mutated_state.packetsAtN,
+                self.mutated_state.packets,
+                self.delays,
+                self.mutated_state.messageSeq
+            )
         else:
             # node configs provided, create nodes with them
             for cfg in self.node_configs:
-                n = MeshNode(self.conf, self.nodes, self.env, self.mutated_state.bc_pipe, self.conf.PERIOD, self.messages, self.mutated_state.packetsAtN, self.mutated_state.packets, self.delays, cfg, self.mutated_state.messageSeq)
+                n = MeshNode(self.conf,
+                    self.nodes,
+                    self.env,
+                    self.mutated_state.bc_pipe,
+                    self.conf.PERIOD,
+                    self.messages,
+                    self.mutated_state.packetsAtN,
+                    self.mutated_state.packets,
+                    self.delays,
+                    cfg,
+                    self.mutated_state.messageSeq
+                )
                 self.nodes.append(n)
 
         if self.graph is not None:

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -26,11 +26,10 @@ class DiscreteEventSim:
     simulation config, all necessary state, and sim plumbing.
     """
 
-    def __init__(self, env: SimpyEnvironment, config: Config, node_configs: [NodeConfig] = [], graph: Graph | None = None):
+    def __init__(self, config: Config, node_configs: [NodeConfig] = [], graph: Graph | None = None):
         """Constructor.
 
         Arguments:
-        env -- SimPy Environment object to use
         config -- Config object defining global constants for simulation.
         node_configs -- Output of parse_params. List of node configurations. Default [].
         graph -- Optional Graph object for GUI. If provided GUI will be used. Default None, for no GUI.
@@ -41,13 +40,13 @@ class DiscreteEventSim:
         # and then only relevant ones passed to the constructor.
 
         # set state from parameters
-        self.env = env
+        self.env = SimpyEnvironment()
         self.conf = config
         self.node_configs = node_configs
         self.nodes = []
 
         # internal state
-        self.bc_pipe = BroadcastPipe(env)
+        self.bc_pipe = BroadcastPipe(self.env)
         self.packets = []
         self.packetsAtN = [[] for _ in range(self.conf.NR_NODES)]
         self.messageSeq = {"val": 0}
@@ -82,7 +81,8 @@ class DiscreteEventSim:
         self.totalPairs, self.symmetricLinks, self.asymmetricLinks, self.noLinks = setup_asymmetric_links(self.conf, self.nodes)
 
         if self.graph is not None and self.conf.MOVEMENT_ENABLED:
-            env.process(run_graph_updates(self.env, self.graph, self.nodes, self.conf.ONE_MIN_INTERVAL))
+            # NOTE: this does not run under test, since we skip creating a GUI
+            self.env.process(run_graph_updates(self.env, self.graph, self.nodes, self.conf.ONE_MIN_INTERVAL))
         self.conf.update_router_dependencies()
 
     def run_simulation(self):

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -8,7 +8,7 @@ from lib.common import setup_asymmetric_links
 from lib.config import Config
 from lib.discrete_event import BroadcastPipe
 from lib.gui import Graph, run_graph_updates
-from lib.node import MeshNode, NodeConfig, generate_node_list
+from lib.node import MeshNode, NodeConfig, default_generate_node_list
 from lib.packet import MeshPacket
 
 logger = logging.getLogger(__name__)
@@ -162,11 +162,12 @@ class DiscreteEventSim:
         # note: we allow user to specify if graphing will happen or not
         self.graph = graph
 
+        # TODO: only use provided node configurations, don't generate our own.
         # create nodes once we have the various things they have to be wired into
         if self.node_configs == [] or self.node_configs[0] is None:
             # default case: no nodes, or default unspecified nodes.
             # generate a default scenario
-            self.nodes = generate_node_list(
+            self.nodes = default_generate_node_list(
                 self.conf,
                 self.node_configs,
                 self.env,

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -65,7 +65,7 @@ class SimulationResults:
         """
         return self.results[subscript]
 
-    def finalize(self, conf: Config, nodes: [MeshNode], packets: [MeshPacket]):
+    def finalize(self, conf: Config):
         """Once simulation is finished, calculate any second-order
         data that is generally useful, such as averages. This requires some extra
         state-related info.
@@ -80,7 +80,9 @@ class SimulationResults:
         packets -- list of packets sent during simulation.
         """
         # replicate result enrichment/calculation from loraMesh.py and batchSim.py
-        sent = len(self.results["packets"])
+        nodes = self.results["nodes"]
+        packets = self.results["packets"]
+        sent = len(packets)
         if conf.DMs:
             self.results["potentialReceivers"] = sent
         else:
@@ -220,7 +222,7 @@ class DiscreteEventSim:
             "nodes": self.nodes,
         }
         results = SimulationResults(first_order_results)
-        results.finalize(self.conf, self.nodes, self.mutated_state.packets)
+        results.finalize(self.conf)
 
         return results
 

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -1,5 +1,6 @@
 import logging
 
+# probably not necessary, but "Environment" seemed too generic to me
 from simpy import Environment as SimpyEnvironment
 
 from lib.common import setup_asymmetric_links
@@ -9,6 +10,29 @@ from lib.gui import Graph, run_graph_updates
 from lib.node import MeshNode, NodeConfig, generate_node_list
 
 logger = logging.getLogger(__name__)
+
+class SimulationState:
+    """Class to hold all global mutated state of a simulation, not including
+    node-specific state such as the position of a moving node.
+    """
+    def __init__(self, config: Config, env: SimpyEnvironment):
+        """Constructor
+
+        Arguments:
+        config -- Config object of global sim constants. Only used for NR_NODES.
+        env -- SimPy Environment for simulation. Required for internal BroadcastPipe.
+        """
+        self.env = env
+        self.bc_pipe = BroadcastPipe(self.env)
+        self.packets = [] # used mostly for data tracking, but also for state
+        self.packetsAtN = [[] for _ in range(config.NR_NODES)]
+        self.messageSeq = {"val": 0} # TODO: turn this into a locked counter
+
+class SimulationDataTracking:
+    """Class to hold data used to monitor a simulation which has no
+    impact on the state or progress of the simulation
+    """
+    pass
 
 class SimulationResults:
     """Class to hold simulation result data. Any interesting or relevant
@@ -20,6 +44,12 @@ class SimulationResults:
     """
     def __init__(self, results: dict):
         self.results = results.copy() # only a shallow copy
+
+    def finalize(self):
+        """Once simulation is finished, calculate any second-order
+        data that is generally useful, such as averages.
+        """
+        pass
 
 class DiscreteEventSim:
     """Class for a full Discrete Event Simulation. Contains
@@ -39,17 +69,16 @@ class DiscreteEventSim:
         # coupling first, so that parameters can be translated/normalized first,
         # and then only relevant ones passed to the constructor.
 
-        # set state from parameters
+        # set constant state/initial state from parameters
         self.env = SimpyEnvironment()
         self.conf = config
         self.node_configs = node_configs
-        self.nodes = []
 
-        # internal state
-        self.bc_pipe = BroadcastPipe(self.env)
-        self.packets = []
-        self.packetsAtN = [[] for _ in range(self.conf.NR_NODES)]
-        self.messageSeq = {"val": 0}
+        # internal global state which changes
+        self.mutated_state = SimulationState(self.conf, self.env)
+
+        # nodes are our actors, so should be separate from our global mutating sim state.
+        self.nodes = []
 
         # stats & data tracking
         self.messages = []
@@ -66,11 +95,11 @@ class DiscreteEventSim:
         if self.node_configs == [] or self.node_configs[0] is None:
             # default case: no nodes, or default unspecified nodes.
             # generate a default scenario
-            self.nodes = generate_node_list(self.conf, self.node_configs, self.env, self.bc_pipe, self.conf.PERIOD, self.messages, self.packetsAtN, self.packets, self.delays, self.messageSeq)
+            self.nodes = generate_node_list(self.conf, self.node_configs, self.env, self.mutated_state.bc_pipe, self.conf.PERIOD, self.messages, self.mutated_state.packetsAtN, self.mutated_state.packets, self.delays, self.mutated_state.messageSeq)
         else:
             # node configs provided, create nodes with them
             for cfg in self.node_configs:
-                n = MeshNode(self.conf, self.nodes, self.env, self.bc_pipe, self.conf.PERIOD, self.messages, self.packetsAtN, self.packets, self.delays, cfg, self.messageSeq)
+                n = MeshNode(self.conf, self.nodes, self.env, self.mutated_state.bc_pipe, self.conf.PERIOD, self.messages, self.mutated_state.packetsAtN, self.mutated_state.packets, self.delays, cfg, self.mutated_state.messageSeq)
                 self.nodes.append(n)
 
         if self.graph is not None:
@@ -99,10 +128,11 @@ class DiscreteEventSim:
 
     # just return a dictionary for now, refactor into an object later
     def get_results(self) -> {}:
+        # first-order stats/data collection
         results = {
-            "packets": self.packets,
-            "packetsAtN": self.packetsAtN,
-            "messageSeq": self.messageSeq,
+            "packets": self.mutated_state.packets,
+            "packetsAtN": self.mutated_state.packetsAtN,
+            "messageSeq": self.mutated_state.messageSeq,
             "messages": self.messages,
             "delays": self.delays,
             "totalPairs": self.totalPairs,
@@ -111,5 +141,7 @@ class DiscreteEventSim:
             "noLinks": self.noLinks,
             "nodes": self.nodes,
         }
+        # TODO: add some universally useful result calculations, like the
+        # ones common between loraMesh.py and batchSim.py
         return results
 

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -82,11 +82,20 @@ class DiscreteEventSim:
 
         if self.graph is not None and self.conf.MOVEMENT_ENABLED:
             # NOTE: this does not run under test, since we skip creating a GUI
+            # TODO: batchSim does this, but without the 4th parameter
             self.env.process(run_graph_updates(self.env, self.graph, self.nodes, self.conf.ONE_MIN_INTERVAL))
         self.conf.update_router_dependencies()
 
     def run_simulation(self):
         self.env.run(until=self.conf.SIMTIME)
+
+    def get_env(self) -> SimpyEnvironment:
+        """get a reference to the Sim's SimPy Environment.
+        Useful for adding your own processes to the environment.
+        Originally a hack to support batchSim.py, which has a progress
+        tracking process
+        """
+        return self.env
 
     # just return a dictionary for now, refactor into an object later
     def get_results(self) -> {}:

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -17,17 +17,17 @@ class SimulationState:
     """Class to hold all global mutated state of a simulation, not including
     node-specific state such as the position of a moving node.
     """
-    def __init__(self, config: Config, env: SimpyEnvironment):
+    def __init__(self, conf: Config, env: SimpyEnvironment):
         """Constructor
 
         Arguments:
-        config -- Config object of global sim constants. Only used for NR_NODES.
+        conf -- Config object of global sim constants. Only used for NR_NODES.
         env -- SimPy Environment for simulation. Required for internal BroadcastPipe.
         """
         self.env = env
         self.bc_pipe = BroadcastPipe(self.env)
         self.packets = [] # used mostly for data tracking, but also for state
-        self.packetsAtN = [[] for _ in range(config.NR_NODES)]
+        self.packetsAtN = [[] for _ in range(conf.NR_NODES)]
         self.messageSeq = {"val": 0} # TODO: turn this into a locked counter
 
 class SimulationDataTracking:
@@ -136,22 +136,18 @@ class DiscreteEventSim:
     simulation config, all necessary state, and sim plumbing.
     """
 
-    def __init__(self, config: Config, node_configs: [NodeConfig] = [], graph: Graph | None = None):
+    def __init__(self, conf: Config, node_configs: [NodeConfig] = [], graph: Graph | None = None):
         """Constructor.
 
         Arguments:
-        config -- Config object defining global constants for simulation.
+        conf -- Config object defining global constants for simulation.
         node_configs -- Output of parse_params. List of node configurations. Default [].
         graph -- Optional Graph object for GUI. If provided GUI will be used. Default None, for no GUI.
         """
-        # InteractiveSim takes argparse output as the single parameter here, tightly
-        # coupling CLI arguments to this class. This works but try with a looser
-        # coupling first, so that parameters can be translated/normalized first,
-        # and then only relevant ones passed to the constructor.
 
         # set constant state/initial state from parameters
         self.env = SimpyEnvironment()
-        self.conf = config
+        self.conf = conf
         self.node_configs = node_configs
 
         # internal global state which changes
@@ -208,6 +204,8 @@ class DiscreteEventSim:
 
         if self.graph is not None and self.conf.MOVEMENT_ENABLED:
             # NOTE: this does not run under test, since we skip creating a GUI
+            # TODO: revisit this design decision sometime. Do we want graphing/GUI to be handled in this object,
+            # or by some external object the user wires in, like how batchSim.py adds in the simulation_progress process?
             # TODO: batchSim does this, but without the 4th parameter
             self.env.process(run_graph_updates(self.env, self.graph, self.nodes, self.conf.ONE_MIN_INTERVAL))
         self.conf.update_router_dependencies()
@@ -241,7 +239,5 @@ class DiscreteEventSim:
         results = SimulationResults(first_order_results)
         results.finalize(self.conf, self.nodes, self.mutated_state.packets)
 
-        # TODO: add some universally useful result calculations, like the
-        # ones common between loraMesh.py and batchSim.py
         return results
 

--- a/lib/node.py
+++ b/lib/node.py
@@ -7,53 +7,13 @@ import random
 import simpy
 
 from lib.common import find_random_position
+from lib.config import Config
 from lib.mac import set_transmit_delay, get_retransmission_msec
 from lib.phy import check_collision, is_channel_active, airtime
 from lib.packet import NODENUM_BROADCAST, MeshPacket, MeshMessage
 from lib.point import Point
 
 logger = logging.getLogger(__name__)
-
-# TODO: convert this to returning a list of NodeConfig objects, greatly simplify
-def default_generate_node_list(conf):
-    """default function for randomly choosing node configurations for a simulation
-    run, based on the provided config and desired number of nodes.
-
-    We have lots of extra parameters that are only really necessary for MeshNode
-    constructor, for tying it in to simulation state stuff. Needs refactoring
-    """
-    # need to identically match RNG usage right now to pass the discrete sim
-    # test. If we want to change the reference test, do that in a smaller change.
-
-    node_configs = []
-
-    # replicate default 'no prior config' setup:
-    for i in range(conf.NR_NODES):
-        # no specified node config, randomly generate one
-        # get node's position
-        x, y = find_random_position(conf, node_configs)
-        z = conf.HM
-        position = Point(x, y, z)
-
-        # role
-        isRouter = conf.router
-        isRepeater = False
-        isClientMute = False
-
-        # other default values
-        hopLimit = conf.hopLimit
-        antennaGain = conf.GL
-
-        # map misc. booleans into single role
-        if isRouter:
-            role = MESHTASTIC_ROLE.ROUTER
-        else:
-            role = MESHTASTIC_ROLE.CLIENT
-
-        # make NodeConfig object to pass to MeshNode constructor
-        node_configs.append(NodeConfig(i, position, role))
-
-    return node_configs
 
 # roles taken from the protobuf config meshtastic/config.proto in https://github.com/meshtastic/protobufs
 # deprecated roles are included for simulation utility
@@ -453,3 +413,41 @@ class MeshNode:
                             self.env.process(self.transmit(pNew))
                 else:
                     self.droppedByDelay += 1
+
+def default_generate_node_list(conf: Config) -> [NodeConfig]:
+    """Default function for randomly choosing node configurations for a simulation
+    run, based on the provided config and desired number of nodes specified in
+    the config.
+    """
+    # need to identically match RNG usage right now to pass the discrete sim
+    # test. If we want to change the reference test, do that in a smaller change.
+
+    node_configs = []
+
+    # replicate default 'no prior config' setup:
+    for i in range(conf.NR_NODES):
+        # no specified node config, randomly generate one
+        # get node's position
+        x, y = find_random_position(conf, node_configs)
+        z = conf.HM
+        position = Point(x, y, z)
+
+        # role
+        isRouter = conf.router
+        isRepeater = False
+        isClientMute = False
+
+        # other default values
+        hopLimit = conf.hopLimit
+        antennaGain = conf.GL
+
+        # map misc. booleans into single role
+        if isRouter:
+            role = MESHTASTIC_ROLE.ROUTER
+        else:
+            role = MESHTASTIC_ROLE.CLIENT
+
+        # make NodeConfig object to pass to MeshNode constructor
+        node_configs.append(NodeConfig(i, position, role))
+
+    return node_configs

--- a/lib/node.py
+++ b/lib/node.py
@@ -15,7 +15,7 @@ from lib.point import Point
 logger = logging.getLogger(__name__)
 
 # TODO: convert this to returning a list of NodeConfig objects, greatly simplify
-def generate_node_list(conf, node_configs, env, bc_pipe, period, messages, packetsAtN, packets, delays, messageSeq):
+def default_generate_node_list(conf, node_configs, env, bc_pipe, period, messages, packetsAtN, packets, delays, messageSeq):
     """default function for randomly choosing node configurations for a simulation
     run, based on the provided config and desired number of nodes.
 

--- a/lib/node.py
+++ b/lib/node.py
@@ -121,6 +121,40 @@ class NodeConfig:
         self.hop_limit = hop_limit
         self.neighbor_info = neighbor_info
 
+    @classmethod
+    def from_gen_scenario_output(cls, node_id: int, node_dict: {}):
+        """create NodeConfig from a node dict as returned from gen_scenario.
+        You probably want to iterate over the keys that function gives you
+        and pass individual values indexed by them to this method.
+
+        Arguments:
+        node_dict -- dictionary defining a single node. From gen_scenario.
+        """
+        nd = node_dict
+        position = Point(nd['x'], nd['y'], nd['z'])
+
+        # roles
+        isRouter = nd['isRouter']
+        isRepeater = nd['isRepeater']
+        isClientMute = nd['isClientMute']
+
+        # sanity check that only one role is set
+        if (isRouter and isRepeater) or \
+           (isRepeater and isClientMute) or \
+           (isClientMute and isRouter):
+           raise Exception(f"invalid combination of roles: {nd}")
+
+        if isRouter:
+            role = MESHTASTIC_ROLE.ROUTER
+        elif isRepeater:
+            role = MESHTASTIC_ROLE.REPEATER
+        elif isClientMute:
+            role = MESHTASTIC_ROLE.CLIENT_MUTE
+        else:
+            role = MESHTASTIC_ROLE.CLIENT
+
+        return NodeConfig(node_id, position, role, nd['antennaGain'], nd['hopLimit'], nd['neighborInfo'])
+
 class MeshNode:
     """Class containing all the particular state of a MeshNode, references to necessary
     external resources like the simpy env, and process functions for simulation

--- a/lib/node.py
+++ b/lib/node.py
@@ -6,7 +6,7 @@ import random
 
 import simpy
 
-from lib.common import find_random_position_nodeconf
+from lib.common import find_random_position
 from lib.mac import set_transmit_delay, get_retransmission_msec
 from lib.phy import check_collision, is_channel_active, airtime
 from lib.packet import NODENUM_BROADCAST, MeshPacket, MeshMessage
@@ -31,7 +31,7 @@ def default_generate_node_list(conf):
     for i in range(conf.NR_NODES):
         # no specified node config, randomly generate one
         # get node's position
-        x, y = find_random_position_nodeconf(conf, node_configs)
+        x, y = find_random_position(conf, node_configs)
         z = conf.HM
         position = Point(x, y, z)
 

--- a/lib/node.py
+++ b/lib/node.py
@@ -14,6 +14,7 @@ from lib.point import Point
 
 logger = logging.getLogger(__name__)
 
+# TODO: convert this to returning a list of NodeConfig objects, greatly simplify
 def generate_node_list(conf, node_configs, env, bc_pipe, period, messages, packetsAtN, packets, delays, messageSeq):
     """default function for randomly choosing node configurations for a simulation
     run, based on the provided config and desired number of nodes.

--- a/lib/node.py
+++ b/lib/node.py
@@ -6,7 +6,7 @@ import random
 
 import simpy
 
-from lib.common import find_random_position
+from lib.common import find_random_position_nodeconf
 from lib.mac import set_transmit_delay, get_retransmission_msec
 from lib.phy import check_collision, is_channel_active, airtime
 from lib.packet import NODENUM_BROADCAST, MeshPacket, MeshMessage
@@ -15,7 +15,7 @@ from lib.point import Point
 logger = logging.getLogger(__name__)
 
 # TODO: convert this to returning a list of NodeConfig objects, greatly simplify
-def default_generate_node_list(conf, node_configs, env, bc_pipe, period, messages, packetsAtN, packets, delays, messageSeq):
+def default_generate_node_list(conf):
     """default function for randomly choosing node configurations for a simulation
     run, based on the provided config and desired number of nodes.
 
@@ -25,73 +25,35 @@ def default_generate_node_list(conf, node_configs, env, bc_pipe, period, message
     # need to identically match RNG usage right now to pass the discrete sim
     # test. If we want to change the reference test, do that in a smaller change.
 
-    nodes = []
+    node_configs = []
 
     # replicate default 'no prior config' setup:
-    i = 0
-    for n in node_configs:
-        if n is None:
-            # no specified node config, randomly generate one
-            # get node's position
-            x, y = find_random_position(conf, nodes)
-            z = conf.HM
-            position = Point(x, y, z)
+    for i in range(conf.NR_NODES):
+        # no specified node config, randomly generate one
+        # get node's position
+        x, y = find_random_position_nodeconf(conf, node_configs)
+        z = conf.HM
+        position = Point(x, y, z)
 
-            # role
-            isRouter = conf.router
-            isRepeater = False
-            isClientMute = False
+        # role
+        isRouter = conf.router
+        isRepeater = False
+        isClientMute = False
 
-            # other default values
-            hopLimit = conf.hopLimit
-            antennaGain = conf.GL
+        # other default values
+        hopLimit = conf.hopLimit
+        antennaGain = conf.GL
 
-            # map misc. booleans into single role
-            if isRouter:
-                role = MESHTASTIC_ROLE.ROUTER
-            else:
-                role = MESHTASTIC_ROLE.CLIENT
-
-            # make NodeConfig object to pass to MeshNode constructor
-            node_config = NodeConfig(i, position, role)
-            i += 1
-
-            # have node config, need to create node, add to list of nodes
-            node = MeshNode(conf, nodes, env, bc_pipe, period, messages, packetsAtN, packets, delays, node_config, messageSeq)
-            nodes.append(node)
+        # map misc. booleans into single role
+        if isRouter:
+            role = MESHTASTIC_ROLE.ROUTER
         else:
-            # convert dict from interactive GUI gen_scenario to NodeConfig objects, create nodes.
-            node_config_dict = node_configs[n]
-            position = Point(node_config_dict['x'], node_config_dict['y'], node_config_dict['z'])
+            role = MESHTASTIC_ROLE.CLIENT
 
-            # roles
-            isRouter = node_config_dict['isRouter']
-            isRepeater = node_config_dict['isRepeater']
-            isClientMute = node_config_dict['isClientMute']
+        # make NodeConfig object to pass to MeshNode constructor
+        node_configs.append(NodeConfig(i, position, role))
 
-            # sanity check that only one role is set
-            if (isRouter and isRepeater) or \
-               (isRepeater and isClientMute) or \
-               (isClientMute and isRouter):
-               raise Exception(f"invalid combination of roles: {node_config_dict}")
-
-            if isRouter:
-                role = MESHTASTIC_ROLE.ROUTER
-            elif isRepeater:
-                role = MESHTASTIC_ROLE.REPEATER
-            elif isClientMute:
-                role = MESHTASTIC_ROLE.CLIENT_MUTE
-            else:
-                role = MESHTASTIC_ROLE.CLIENT
-
-            # make node config
-            node_config = NodeConfig(i, position, role, node_config_dict['antennaGain'], node_config_dict['hopLimit'], node_config_dict['neighborInfo'])
-            i += 1
-
-            node = MeshNode(conf, nodes, env, bc_pipe, period, messages, packetsAtN, packets, delays, node_config, messageSeq)
-            nodes.append(node)
-
-    return nodes
+    return node_configs
 
 # roles taken from the protobuf config meshtastic/config.proto in https://github.com/meshtastic/protobufs
 # deprecated roles are included for simulation utility

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -9,11 +9,9 @@ import yaml
 import simpy
 import numpy as np
 
-from lib.common import setup_asymmetric_links
 from lib.config import CONFIG
-from lib.discrete_event import BroadcastPipe
+from lib.discrete_event_sim import DiscreteEventSim
 from lib.gui import Graph, plot_schedule, gen_scenario, run_graph_updates
-from lib.node import MeshNode, generate_node_list
 
 conf = CONFIG
 random.seed(conf.SEED)
@@ -87,42 +85,34 @@ def parse_params(conf, args):
     print("Interference level:", conf.INTERFERENCE_LEVEL)
     return config
 
-
 nodeConfig = parse_params(conf, sys.argv)
 conf.update_router_dependencies()
 env = simpy.Environment()
-bc_pipe = BroadcastPipe(env)
-
-# simulation variables
-messages = []
-packets = []
-delays = []
-packetsAtN = [[] for _ in range(conf.NR_NODES)]
-messageSeq = {"val": 0}
-totalPairs = 0
-symmetricLinks = 0
-asymmetricLinks = 0
-noLinks = 0
-
 graph = Graph(conf)
 
-nodes = generate_node_list(conf, nodeConfig, env, bc_pipe, conf.PERIOD, messages, packetsAtN, packets, delays, messageSeq)
-for n in nodes:
-    graph.add_node(n)
+# set up sim
+sim = DiscreteEventSim(env, conf, nodeConfig, graph)
 
-totalPairs, symmetricLinks, asymmetricLinks, noLinks = setup_asymmetric_links(conf, nodes)
-
-if conf.MOVEMENT_ENABLED:
-    env.process(run_graph_updates(env, graph, nodes, conf.ONE_MIN_INTERVAL))
-
-conf.update_router_dependencies()
-
-# start simulation
+# run sim
 print("\n====== START OF SIMULATION ======")
-env.run(until=conf.SIMTIME)
+sim.run_simulation()
 
-# compute statistics
+# collect, process & display results
 print("\n====== END OF SIMULATION ======")
+
+results = sim.get_results()
+
+packets = results["packets"]
+packetsAtN = results["packetsAtN"]
+messageSeq = results["messageSeq"]
+messages = results["messages"]
+delays = results["delays"]
+totalPairs = results["totalPairs"]
+symmetricLinks = results["symmetricLinks"]
+asymmetricLinks = results["asymmetricLinks"]
+noLinks = results["noLinks"]
+nodes = results["nodes"]
+
 print("*******************************")
 print(f"\nRouter Type: {conf.SELECTED_ROUTER_TYPE}")
 print('Number of messages created:', messageSeq["val"])

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -111,49 +111,45 @@ asymmetricLinks = results["asymmetricLinks"]
 noLinks = results["noLinks"]
 nodes = results["nodes"]
 
+# collect second-order results from finalized results
+sent = results['sent']
+potentialReceivers = results['potentialReceivers']
+nrCollisions = results['nrCollisions']
+nrSensed = results['nrSensed']
+nrReceived = results['nrReceived']
+meanDelay = results['meanDelay']
+txAirUtilization = results['txAirUtilization']
+collisionRate = results['collisionRate']
+nodeReach = results['nodeReach']
+usefulness = results['usefulness']
+delayDropped = results['delayDropped']
+
 print("*******************************")
 print(f"\nRouter Type: {conf.SELECTED_ROUTER_TYPE}")
 print('Number of messages created:', messageSeq["val"])
-sent = len(packets)
-if conf.DMs:
-    potentialReceivers = sent
-else:
-    potentialReceivers = sent*(conf.NR_NODES-1)
 print('Number of packets sent:', sent, 'to', potentialReceivers, 'potential receivers')
-nrCollisions = sum([1 for p in packets for n in nodes if p.collidedAtN[n.nodeid] is True])
 print("Number of collisions:", nrCollisions)
-nrSensed = sum([1 for p in packets for n in nodes if p.sensedByN[n.nodeid] is True])
 print("Number of packets sensed:", nrSensed)
-nrReceived = sum([1 for p in packets for n in nodes if p.receivedAtN[n.nodeid] is True])
 print("Number of packets received:", nrReceived)
-meanDelay = np.nanmean(delays)
 print('Delay average (ms):', round(meanDelay, 2))
-txAirUtilization = sum([n.txAirUtilization for n in nodes])/conf.NR_NODES/conf.SIMTIME*100
-print('Average Tx air utilization:', round(txAirUtilization, 2), '%')
-if nrSensed != 0:
-    collisionRate = float((nrCollisions)/nrSensed)
-    print("Percentage of packets that collided:", round(collisionRate*100, 2))
-else:
-    print("No packets sensed.")
-nodeReach = sum([n.usefulPackets for n in nodes])/(messageSeq["val"]*(conf.NR_NODES-1))
+print('Average Tx air utilization:', round(txAirUtilization * 100, 2), '%')
+print("Percentage of packets that collided:", round(collisionRate*100, 2))
 print("Average percentage of nodes reached:", round(nodeReach*100, 2))
-if nrReceived != 0:
-    usefulness = sum([n.usefulPackets for n in nodes])/nrReceived  # nr of packets that delivered to a packet to a new receiver out of all packets sent
-    print("Percentage of received packets containing new message:", round(usefulness*100, 2))
-else:
-    print('No packets received.')
-delayDropped = sum(n.droppedByDelay for n in nodes)
+print("Percentage of received packets containing new message:", round(usefulness*100, 2))
 print("Number of packets dropped by delay/hop limit:", delayDropped)
 
 if conf.MODEL_ASYMMETRIC_LINKS:
-    print("Asymmetric links:", round(asymmetricLinks / totalPairs * 100, 2), '%')
-    print("Symmetric links:", round(symmetricLinks / totalPairs * 100, 2), '%')
-    print("No links:", round(noLinks / totalPairs * 100, 2), '%')
+    asymmetricLinkRate = results['asymmetricLinkRate']
+    symmetricLinkRate = results['symmetricLinkRate']
+    noLinkRate = results['noLinkRate']
+    print("Asymmetric links:", round(asymmetricLinkRate * 100, 2), '%')
+    print("Symmetric links:", round(symmetricLinkRate * 100, 2), '%')
+    print("No links:", round(noLinkRate * 100, 2), '%')
 
 if conf.MOVEMENT_ENABLED:
-    movingNodes = sum([1 for n in nodes if n.isMoving is True])
+    movingNodes = results['movingNodes']
+    gpsEnabled = results['gpsEnabled']
     print("Number of moving nodes:", movingNodes)
-    gpsEnabled = sum([1 for n in nodes if n.gpsEnabled is True])
     print("Number of moving nodes w/ GPS:", gpsEnabled)
 
 graph.save()

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -6,7 +6,6 @@ import sys
 import random
 
 import yaml
-import simpy
 import numpy as np
 
 from lib.config import CONFIG
@@ -87,11 +86,10 @@ def parse_params(conf, args):
 
 nodeConfig = parse_params(conf, sys.argv)
 conf.update_router_dependencies()
-env = simpy.Environment()
 graph = Graph(conf)
 
 # set up sim
-sim = DiscreteEventSim(env, conf, nodeConfig, graph)
+sim = DiscreteEventSim(conf, nodeConfig, graph)
 
 # run sim
 print("\n====== START OF SIMULATION ======")

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -118,7 +118,7 @@ nrCollisions = results['nrCollisions']
 nrSensed = results['nrSensed']
 nrReceived = results['nrReceived']
 meanDelay = results['meanDelay']
-txAirUtilization = results['txAirUtilization']
+txAirUtilizationRate = results['txAirUtilizationRate']
 collisionRate = results['collisionRate']
 nodeReach = results['nodeReach']
 usefulness = results['usefulness']
@@ -132,7 +132,7 @@ print("Number of collisions:", nrCollisions)
 print("Number of packets sensed:", nrSensed)
 print("Number of packets received:", nrReceived)
 print('Delay average (ms):', round(meanDelay, 2))
-print('Average Tx air utilization:', round(txAirUtilization * 100, 2), '%')
+print('Average Tx air utilization:', round(txAirUtilizationRate * 100, 2), '%')
 print("Percentage of packets that collided:", round(collisionRate*100, 2))
 print("Average percentage of nodes reached:", round(nodeReach*100, 2))
 print("Percentage of received packets containing new message:", round(usefulness*100, 2))

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from lib.config import CONFIG
 from lib.discrete_event_sim import DiscreteEventSim
+from lib.node import NodeConfig, default_generate_node_list
 from lib.gui import Graph, plot_schedule, gen_scenario
 
 conf = CONFIG
@@ -19,7 +20,7 @@ logging.basicConfig(level=logging.INFO) # default log level
 
 log_level = logging.INFO
 
-def parse_params(conf, args):
+def parse_params(conf, args) -> [NodeConfig]:
     """parses command-line arguments, alters global simulation config, and returns
     a list of node configurations, or a list of None.
     """
@@ -60,19 +61,19 @@ def parse_params(conf, args):
     if parsed_arguments.from_file is not None:
         with open(os.path.join("out", parsed_arguments.from_file), 'r') as file:
             config = yaml.load(file, Loader=yaml.FullLoader)
+        conf.NR_NODES = len(config.keys())
     elif parsed_arguments.nr_nodes is not None:
         conf.NR_NODES = parsed_arguments.nr_nodes
-        config = [None for _ in range(conf.NR_NODES)]
         if parsed_arguments.router_type is not None:
             routerType = parsed_arguments.router_type
             conf.SELECTED_ROUTER_TYPE = routerType
             conf.update_router_dependencies()
+        # put after router type selection, in case that affects placement, etc.
+        config = default_generate_node_list(conf)
     else:
-        config = gen_scenario(conf)
-
-    if config[0] is not None:
-        # yaml file or unspecified nr_nodes
-        conf.NR_NODES = len(config.keys())
+        config_dict = gen_scenario(conf)
+        config = [NodeConfig.from_gen_scenario_output(node_id, cfg) for node_id, cfg in config_dict.items()]
+        conf.NR_NODES = len(config)
 
     if conf.NR_NODES < 2:
         parser.error(f"Need at least two nodes. You specified {conf.NR_NODES}")

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from lib.config import CONFIG
 from lib.discrete_event_sim import DiscreteEventSim
-from lib.gui import Graph, plot_schedule, gen_scenario, run_graph_updates
+from lib.gui import Graph, plot_schedule, gen_scenario
 
 conf = CONFIG
 random.seed(conf.SEED)

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -76,8 +76,8 @@ class TestDiscreteEventSim(unittest.TestCase):
         self.assertEqual(nrReceived, 2743, "expected number of packets received")
         meanDelay = results['meanDelay']
         self.assertEqual(round(meanDelay, 2), 9465.81, "expected rounded delay average")
-        txAirUtilization = results['txAirUtilization']
-        self.assertEqual(round(txAirUtilization * 100, 2), 5.06, "expected rounded average tx air utilization")
+        txAirUtilizationRate = results['txAirUtilizationRate']
+        self.assertEqual(round(txAirUtilizationRate * 100, 2), 5.06, "expected rounded average tx air utilization")
 
         nodeReach = results['nodeReach']
         self.assertEqual(round(nodeReach*100, 2), 85.06, "expected rounded percentage of nodes reached")

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -13,6 +13,7 @@ class TestDiscreteEventSim(unittest.TestCase):
     of the sim doesn't change. Or if the prior behavior was mistaken or
     incorrect, we can update this test.
     '''
+    # TODO: add many more tests for SimulationResults, especially finalize method
 
     # TODO: add default-skip GUI test?
     def test_discrete_sim_ten_nodes(self):
@@ -39,6 +40,7 @@ class TestDiscreteEventSim(unittest.TestCase):
         # collect & unpack results for easy copy/paste of asserts
         results = sim.get_results()
 
+        # put "first order" results in local scope for easy access
         packets = results["packets"]
         packetsAtN = results["packetsAtN"]
         messageSeq = results["messageSeq"]
@@ -60,43 +62,43 @@ class TestDiscreteEventSim(unittest.TestCase):
         # simulation results is up to your judgement for which is
         # appropriate. Be cautious!
         self.assertEqual(messageSeq["val"], 180, "expected number of messages created")
-        sent = len(packets)
-        if conf.DMs:
-            potentialReceivers = sent
-        else:
-            potentialReceivers = sent*(conf.NR_NODES-1)
+        sent = results['sent']
+        potentialReceivers = results['potentialReceivers']
         self.assertEqual(sent, 875, "expected number of packets sent")
         self.assertEqual(potentialReceivers, 7875, "expected number of potential receivers")
 
-        nrCollisions = sum([1 for p in packets for n in nodes if p.collidedAtN[n.nodeid] is True])
+        nrCollisions = results['nrCollisions']
         self.assertEqual(nrCollisions, 320, "expected number of collisions")
-        nrSensed = sum([1 for p in packets for n in nodes if p.sensedByN[n.nodeid] is True])
+        nrSensed = results['nrSensed']
         self.assertEqual(nrSensed, 3071, "expected number of packets sensed")
 
-        nrReceived = sum([1 for p in packets for n in nodes if p.receivedAtN[n.nodeid] is True])
+        nrReceived = results['nrReceived']
         self.assertEqual(nrReceived, 2743, "expected number of packets received")
-        meanDelay = np.nanmean(delays)
+        meanDelay = results['meanDelay']
         self.assertEqual(round(meanDelay, 2), 9465.81, "expected rounded delay average")
-        txAirUtilization = sum([n.txAirUtilization for n in nodes])/conf.NR_NODES/conf.SIMTIME*100
-        self.assertEqual(round(txAirUtilization, 2), 5.06, "expected rounded average tx air utilization")
+        txAirUtilization = results['txAirUtilization']
+        self.assertEqual(round(txAirUtilization * 100, 2), 5.06, "expected rounded average tx air utilization")
 
-        nodeReach = sum([n.usefulPackets for n in nodes])/(messageSeq["val"]*(conf.NR_NODES-1))
+        nodeReach = results['nodeReach']
         self.assertEqual(round(nodeReach*100, 2), 85.06, "expected rounded percentage of nodes reached")
 
-        usefulness = sum([n.usefulPackets for n in nodes])/nrReceived  # nr of packets that delivered to a packet to a new receiver out of all packets sent
+        usefulness = results['usefulness']
         self.assertEqual(round(usefulness*100, 2), 50.24, "expected rounded 'usefulness' percentage")
 
-        delayDropped = sum(n.droppedByDelay for n in nodes)
+        delayDropped = results['delayDropped']
         self.assertEqual(delayDropped, 1255, "expected number of packets dropped")
         # default config has both asymmetric links and movement enabled
-        self.assertEqual(round(asymmetricLinks / totalPairs * 100, 2), 8.89, "expected rounded percentage of asymmetric links")
-        self.assertEqual(round(symmetricLinks / totalPairs * 100, 2), 42.22, "expected rounded percentage of symmetric links")
-        self.assertEqual(round(noLinks / totalPairs * 100, 2), 48.89, "expected rounded percentage of 'no' links")
+        asymmetricLinkRate = results['asymmetricLinkRate']
+        self.assertEqual(round(asymmetricLinkRate * 100, 2), 8.89, "expected rounded percentage of asymmetric links")
+        symmetricLinkRate = results['symmetricLinkRate']
+        self.assertEqual(round(symmetricLinkRate * 100, 2), 42.22, "expected rounded percentage of symmetric links")
+        noLinkRate = results['noLinkRate']
+        self.assertEqual(round(noLinkRate * 100, 2), 48.89, "expected rounded percentage of 'no' links")
 
-        movingNodes = sum([1 for n in nodes if n.isMoving is True])
+        movingNodes = results['movingNodes']
         self.assertEqual(movingNodes, 4, "expected number of moving nodes")
 
-        gpsEnabled = sum([1 for n in nodes if n.gpsEnabled is True])
+        gpsEnabled = results['gpsEnabled']
         self.assertEqual(gpsEnabled, 1, "expected number of nodes with GPS")
 
 if __name__ == '__main__':

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -16,7 +16,6 @@ class TestDiscreteEventSim(unittest.TestCase):
 
     # TODO: add default-skip GUI test?
     def test_discrete_sim_ten_nodes(self):
-        import simpy
         import numpy as np
 
         from lib.config import CONFIG
@@ -31,11 +30,10 @@ class TestDiscreteEventSim(unittest.TestCase):
         conf.NR_NODES = 10
         nodeConfig = [None for _ in range(conf.NR_NODES)]
         conf.update_router_dependencies()
-        env = simpy.Environment()
         # skipping GUI graphing to speed things up
 
         # set up sim
-        sim = lib.discrete_event_sim.DiscreteEventSim(env, conf, nodeConfig)
+        sim = lib.discrete_event_sim.DiscreteEventSim(conf, nodeConfig)
         sim.run_simulation()
 
         # collect & unpack results for easy copy/paste of asserts

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -1,13 +1,10 @@
 import random
 import unittest
 
-from lib.config import CONFIG
+import lib.discrete_event_sim
 
-conf = CONFIG
-
-class TestFullDiscreteSim(unittest.TestCase):
-    '''
-    manually replicate a 10-node default configuration discrete sim test as
+class TestDiscreteEventSim(unittest.TestCase):
+    '''manually replicate a 10-node default configuration discrete sim test as
     if executing `loraMesh.py 10`. Set up the config to match our previous
     known good test run, run the sim, then check against some hardcoded
     results from a previous known good test run.
@@ -17,60 +14,43 @@ class TestFullDiscreteSim(unittest.TestCase):
     incorrect, we can update this test.
     '''
 
+    # TODO: add default-skip GUI test?
     def test_discrete_sim_ten_nodes(self):
         import simpy
         import numpy as np
 
-        from lib.common import setup_asymmetric_links
-        from lib.discrete_event import BroadcastPipe
-        from lib.gui import Graph, run_graph_updates
-        from lib.node import MeshNode, generate_node_list
+        from lib.config import CONFIG
+        conf = CONFIG
 
         # crucial!! and perhaps a tad fragile
         random.seed(conf.SEED)
 
         self.assertEqual(conf.SEED, 44, "expected default seed for rng")
 
-        # initial version: get the config, then just change what
-        # parse_params would change.
-        # TODO: have our own replicate of our reference config, so we
-        # have to explicitly update the test when we change config defaults
+        # imitate parse_params
         conf.NR_NODES = 10
-
         nodeConfig = [None for _ in range(conf.NR_NODES)]
         conf.update_router_dependencies()
         env = simpy.Environment()
-        bc_pipe = BroadcastPipe(env)
+        # skipping GUI graphing to speed things up
 
-        # begin loraMesh.py copypasta, so we can replicate running a sim
-        # simulation variables
-        nodes = []
-        messages = []
-        packets = []
-        delays = []
-        packetsAtN = [[] for _ in range(conf.NR_NODES)]
-        messageSeq = {"val": 0}
-        totalPairs = 0
-        symmetricLinks = 0
-        asymmetricLinks = 0
-        noLinks = 0
+        # set up sim
+        sim = lib.discrete_event_sim.DiscreteEventSim(env, conf, nodeConfig)
+        sim.run_simulation()
 
-        graph = Graph(conf)
+        # collect & unpack results for easy copy/paste of asserts
+        results = sim.get_results()
 
-        nodes = generate_node_list(conf, nodeConfig, env, bc_pipe, conf.PERIOD, messages, packetsAtN, packets, delays, messageSeq)
-        for n in nodes:
-            graph.add_node(n)
-
-        totalPairs, symmetricLinks, asymmetricLinks, noLinks = setup_asymmetric_links(conf, nodes)
-
-        if conf.MOVEMENT_ENABLED:
-            env.process(run_graph_updates(env, graph, nodes, conf.ONE_MIN_INTERVAL))
-
-        conf.update_router_dependencies()
-
-        # TODO: disable GUI for this, since IMO that's unwanted when running tests
-        env.run(until=conf.SIMTIME)
-        # end loraMesh.py copypasta
+        packets = results["packets"]
+        packetsAtN = results["packetsAtN"]
+        messageSeq = results["messageSeq"]
+        messages = results["messages"]
+        delays = results["delays"]
+        totalPairs = results["totalPairs"]
+        symmetricLinks = results["symmetricLinks"]
+        asymmetricLinks = results["asymmetricLinks"]
+        noLinks = results["noLinks"]
+        nodes = results["nodes"]
 
         # Begin actual tests, comparing against a hardcoded 'known
         # good' run. If these fail then a change has impacted the

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -19,6 +19,8 @@ class TestDiscreteEventSim(unittest.TestCase):
     def test_discrete_sim_ten_nodes(self):
         import numpy as np
 
+        from lib.node import default_generate_node_list
+
         from lib.config import CONFIG
         conf = CONFIG
 
@@ -29,8 +31,8 @@ class TestDiscreteEventSim(unittest.TestCase):
 
         # imitate parse_params
         conf.NR_NODES = 10
-        nodeConfig = [None for _ in range(conf.NR_NODES)]
         conf.update_router_dependencies()
+        nodeConfig = default_generate_node_list(conf)
         # skipping GUI graphing to speed things up
 
         # set up sim

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -15,6 +15,144 @@ class TestDiscreteEventSim(unittest.TestCase):
     '''
     # TODO: add many more tests for SimulationResults, especially finalize method
 
+    def test_simulation_results_finalization(self):
+        """SimulationResults is a glorified dictionary, but the finalize
+        method does a notable number of simple calculations and makes a
+        notable number of assumptions on keys that exist. Do some
+        rudimentary testing with mock types, since it expects lists of
+        MeshNode and MeshPacket objects.
+        """
+        from lib.config import CONFIG
+        conf = CONFIG
+
+        # nodes must have attributes:
+        # - nodeid (int)
+        # - usefulPackets (int)
+        # - txAirUtilization (float?)
+        # - droppedByDelay (int)
+        # - isMoving (boolean)
+        # - gpsEnabled (boolean)
+
+        # packets must have attributes:
+        # (lists which are as long as there are nodes)
+        # - collidedAtN list (boolean)
+        # - sensedByN list (boolean)
+        # - receivedAtN list (boolean)
+
+        # first-order results must have keys:
+        # - nodes (list of nodes)
+        # - packets (list of packets)
+        # - delays (list of ...floats?)
+        # - messageSeq["val"] - total # of messages
+        # - totalPairs (int)
+        # - asymmetricLinks (int)
+        # - symmetricLinks (int)
+        # - noLinks (int)
+
+        # Things which are computed (keys in results):
+        # *: conditional on a config setting
+        # +: gated by division-by-zero check of some value (may be nan)
+        # - potentialReceivers *
+        # - sent
+        # - nrCollisions
+        # - nrSensed
+        # - nrReceived
+        # - nrUseful
+        # - meanDelay
+        # - txAirUtilizationRate *+
+        # - collisionRate +
+        # - nodereach *+
+        # - usefulness +
+        # - delayDropped
+        # - symmetricLinkRate *+
+        # - asymmetricLinkRate *+
+        # - noLinkRate *+
+        # - movingNodes *
+        # - gpsEnabled *
+
+        class MockNode:
+            def __init__(self, nodeid: int):
+                self.nodeid = nodeid
+                self.usefulPackets = 0
+                self.txAirUtilization = 0.0
+                self.droppedByDelay = 0
+                self.isMoving = False
+                self.gpsEnabled = False
+
+        class MockPacket:
+            def __init__(self, num_nodes: int):
+                self.collidedAtN = [False for _ in range(num_nodes)]
+                self.sensedByN = [False for _ in range(num_nodes)]
+                self.receivedAtN = [False for _ in range(num_nodes)]
+
+        # mock situation: 3 nodes who can all mutually see each other, no DMs,
+        # moving nodes, asymmetric links (default config)
+        # (complete graph. Triangle)
+        # 10 messages and 10 packets
+        # I probably won't make this perfect, but want some basic numbers
+        conf.NR_NODES = 3
+        mock_nodes = [MockNode(i) for i in range(3)]
+        mock_nodes[0].isMoving = True
+        mock_nodes[0].gpsEnabled = True
+        for n in mock_nodes:
+            # just put some non-zero values in there
+            n.usefulPackets = 10
+            n.txAirUtilization = 1.0
+
+        mock_packets = [MockPacket(3) for i in range(10)]
+        # all packets were sensed by all nodes, no collisions (fudging it)
+        for p in mock_packets:
+            for i in range(3):
+                p.sensedByN[i] = True
+                p.receivedAtN[i] = True
+
+        r = {}
+        r['nodes'] = mock_nodes
+        r['packets'] = mock_packets
+        r['delays'] = [1.0 for _ in range(10)]
+        r['messageSeq'] = {'val': 10} # total # of messages (not packets)
+
+        # as set up, totalPairs = symmetricLinks + asymmetricLinks + noLinks
+        r['totalPairs'] = 3
+        r['asymmetricLinks'] = 0
+        r['symmetricLinks'] = 0
+        r['noLinks'] = 0
+
+        sim_results = lib.discrete_event_sim.SimulationResults(r)
+        sim_results.finalize(conf)
+
+        # test computations done by finalize, sanity checks
+
+        # keys exist AND are specific good values
+        self.assertEqual(sim_results['potentialReceivers'], len(mock_packets) * (conf.NR_NODES - 1), "expected calculation of potential receivers (no DMs)")
+        self.assertEqual(sim_results['sent'], len(mock_packets), 'expected calculation of sent packets')
+        self.assertEqual(sim_results['nrCollisions'], 0, 'expected nr of collisions')
+        self.assertEqual(sim_results['nrSensed'], 30, 'expected nr of sensed packets')
+        self.assertEqual(sim_results['nrReceived'], 30, 'expected nr of received packets')
+        self.assertEqual(sim_results['nrUseful'], 30, 'expected nr of useful packets')
+        self.assertEqual(sim_results['meanDelay'], 1.0, 'expected mean delay')
+        self.assertEqual(sim_results['collisionRate'], 0, 'expected calculated collisionRate')
+        self.assertEqual(sim_results['usefulness'], 1, 'usefulness is created')
+        self.assertEqual(sim_results['delayDropped'], 0, 'expected number of delayDropped')
+
+        # keys exist, not currently checking values
+        self.assertIsNotNone(sim_results['txAirUtilizationRate'], 'txAirUtilizationRate is created')
+        self.assertIsNotNone(sim_results['nodeReach'], 'nodeReach is created')
+        #self.assertIsNotNone(sim_results['x'], 'x is created')
+
+        # check rate calculations in [0, 1] (assuming we mocked sane values)
+        self.assertLessEqual(0.0, sim_results['asymmetricLinkRate'], 'calculated asymmetricLinkRate is above or equal to 0')
+        self.assertLessEqual(sim_results['asymmetricLinkRate'], 1.0, 'calculated asymmetricLinkRate is below or equal to 1')
+        self.assertLessEqual(0.0, sim_results['symmetricLinkRate'], 'calculated symmetricLinkRate is above or equal to 0')
+        self.assertLessEqual(sim_results['symmetricLinkRate'], 1.0, 'calculated symmetricLinkRate is below or equal to 1')
+        self.assertLessEqual(0.0, sim_results['noLinkRate'], 'calculated noLinkRate is above or equal to 0')
+        self.assertLessEqual(sim_results['noLinkRate'], 1.0, 'calculated noLinkRate is below or equal to 1')
+
+        # expect only 1 moving node with gps enabled
+        self.assertEqual(sim_results['movingNodes'], 1, 'expected number of moving nodes')
+        self.assertEqual(sim_results['gpsEnabled'], 1, 'expected number of gps enabled nodes')
+
+
     # TODO: add default-skip GUI test?
     def test_discrete_sim_ten_nodes(self):
         import numpy as np


### PR DESCRIPTION
Big changes. There's more things I'd like to do (smaller refactors, more tests for SimulationResults class) but this felt like a big enough change to submit on its own.

The simulation meta-object lets us keep more of the setup, running, and data collecting part of the sim in one place. The user just has to give it the overall config and a set of node configs and it can handle everything else, including collecting sim results and calculating things from them like various rates. loraMesh.py and batchSim.py are updated to use it, and the previous "full sim" unit test has basically been moved into a test of the DiscreteEventSim class.

This should make it much easier to do things like run multiple simulations at once, or run identical simulations with only a single variable changed to precisely compare potential changes or misc. setup differences.