### PR TITLE
Refactor/#58 refactor meshnode split sim plumbing

### DIFF
--- a/batchSim.py
+++ b/batchSim.py
@@ -240,7 +240,7 @@ for rt_i, routerType in enumerate(routerTypes):
                 x, y = coords[nodeId]
 
                 # We create a NodeConfig object so that MeshNode will use that
-                nodeConfig = NodeConfig(nodeId, Point(x, y, routerTypeConf.HM), antenna_gain=routerTypeConf.GL, hop_limit=routerTypeConf.hopLimit)
+                nodeConfig = NodeConfig(nodeId, Point(x, y, routerTypeConf.HM), routerTypeConf.PERIOD, antenna_gain=routerTypeConf.GL, hop_limit=routerTypeConf.hopLimit)
                 node_configs.append(nodeConfig)
 
             if SHOW_GRAPH:

--- a/batchSim.py
+++ b/batchSim.py
@@ -326,7 +326,7 @@ for rt_i, routerType in enumerate(routerTypes):
                 "SIMTIME": routerTypeConf.SIMTIME,
                 "PERIOD": routerTypeConf.PERIOD,
                 "PACKETLENGTH": routerTypeConf.PACKETLENGTH,
-                "nrMessages": messageSeq["val"],
+                "nrMessages": messageSeq,
                 "SELECTED_ROUTER_TYPE": routerTypeLabel
             }
             subdir = "hopLimit3"

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -127,9 +127,6 @@ class DiscreteEventSim:
         # internal global state which changes
         self.mutated_state = SimulationState(self.conf, self.env)
 
-        # nodes are our actors, so should be separate from our global mutating sim state.
-        self.nodes = []
-
         # stats & data tracking
         self.data_tracking = SimulationDataTracking()
 
@@ -139,26 +136,25 @@ class DiscreteEventSim:
         # node configs provided, create nodes with them
         for cfg in self.node_configs:
             n = MeshNode(self.conf,
-                self.nodes,
                 self.mutated_state,
                 self.data_tracking,
                 cfg,
             )
-            self.nodes.append(n)
+            self.mutated_state.nodes.append(n)
 
         if self.graph is not None:
-            for n in self.nodes:
+            for n in self.mutated_state.nodes:
                 self.graph.add_node(n)
 
         # setup that requires having nodes
-        self.data_tracking.totalPairs, self.data_tracking.symmetricLinks, self.data_tracking.asymmetricLinks, self.data_tracking.noLinks = setup_asymmetric_links(self.conf, self.nodes)
+        self.data_tracking.totalPairs, self.data_tracking.symmetricLinks, self.data_tracking.asymmetricLinks, self.data_tracking.noLinks = setup_asymmetric_links(self.conf, self.mutated_state.nodes)
 
         if self.graph is not None and self.conf.MOVEMENT_ENABLED:
             # NOTE: this does not run under test, since we skip creating a GUI
             # TODO: revisit this design decision sometime. Do we want graphing/GUI to be handled in this object,
             # or by some external object the user wires in, like how batchSim.py adds in the simulation_progress process?
             # TODO: batchSim does this, but without the 4th parameter
-            self.env.process(run_graph_updates(self.env, self.graph, self.nodes, self.conf.ONE_MIN_INTERVAL))
+            self.env.process(run_graph_updates(self.env, self.graph, self.mutated_state.nodes, self.conf.ONE_MIN_INTERVAL))
         self.conf.update_router_dependencies()
 
     def run_simulation(self):
@@ -181,7 +177,7 @@ class DiscreteEventSim:
         # before, each node just appended to the list and it was naturally sorted.
         # May decide to undo this refactor later.
         messages = []
-        node_stats = [n.get_stats() for n in self.nodes]
+        node_stats = [n.get_stats() for n in self.mutated_state.nodes]
         for stats in node_stats:
             messages.extend(stats.messages)
         messages.sort(key=lambda m: m.genTime)
@@ -196,7 +192,7 @@ class DiscreteEventSim:
             "symmetricLinks": self.data_tracking.symmetricLinks,
             "asymmetricLinks": self.data_tracking.asymmetricLinks,
             "noLinks": self.data_tracking.noLinks,
-            "nodes": self.nodes,
+            "nodes": self.mutated_state.nodes,
         }
         results = SimulationResults(first_order_results)
         results.finalize(self.conf)

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -7,40 +7,12 @@ import numpy as np
 from lib.common import setup_asymmetric_links
 from lib.config import Config
 from lib.discrete_event import BroadcastPipe
+from lib.discrete_event_sim_components import SimulationState, SimulationDataTracking
 from lib.gui import Graph, run_graph_updates
 from lib.node import MeshNode, NodeConfig, default_generate_node_list
 from lib.packet import MeshPacket
 
 logger = logging.getLogger(__name__)
-
-class SimulationState:
-    """Class to hold all global mutated state of a simulation, not including
-    node-specific state such as the position of a moving node.
-    """
-    def __init__(self, conf: Config, env: SimpyEnvironment):
-        """Constructor
-
-        Arguments:
-        conf -- Config object of global sim constants. Only used for NR_NODES.
-        env -- SimPy Environment for simulation. Required for internal BroadcastPipe.
-        """
-        self.env = env
-        self.bc_pipe = BroadcastPipe(self.env)
-        self.packets = [] # used mostly for data tracking, but also for state
-        self.packetsAtN = [[] for _ in range(conf.NR_NODES)]
-        self.messageSeq = {"val": 0} # TODO: turn this into a locked counter
-
-class SimulationDataTracking:
-    """Class to hold data used to monitor a simulation which has no
-    impact on the state or progress of the simulation
-    """
-    def __init__(self):
-        self.messages = []
-        self.delays = []
-        self.totalPairs = 0
-        self.symmetricLinks = 0
-        self.asymmetricLinks = 0
-        self.noLinks = 0
 
 class SimulationResults:
     """Class to hold simulation result data. Any interesting or relevant
@@ -168,13 +140,9 @@ class DiscreteEventSim:
         for cfg in self.node_configs:
             n = MeshNode(self.conf,
                 self.nodes,
-                self.env,
-                self.mutated_state.bc_pipe,
-                self.mutated_state.packetsAtN,
-                self.mutated_state.packets,
-                self.data_tracking.delays,
+                self.mutated_state,
+                self.data_tracking,
                 cfg,
-                self.mutated_state.messageSeq
             )
             self.nodes.append(n)
 

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -171,7 +171,6 @@ class DiscreteEventSim:
                 self.env,
                 self.mutated_state.bc_pipe,
                 self.conf.PERIOD,
-                self.data_tracking.messages,
                 self.mutated_state.packetsAtN,
                 self.mutated_state.packets,
                 self.data_tracking.delays,
@@ -209,11 +208,22 @@ class DiscreteEventSim:
     def get_results(self) -> SimulationResults:
         # TODO: is it possible to add a check that the sim has finished running?
         # first-order stats/data collection
+
+        # collect messages from each node, put into single sorted list.
+        # This saves a parameter from MeshNode, but arguably adds complexity when
+        # before, each node just appended to the list and it was naturally sorted.
+        # May decide to undo this refactor later.
+        messages = []
+        node_stats = [n.get_stats() for n in self.nodes]
+        for stats in node_stats:
+            messages.extend(stats.messages)
+        messages.sort(key=lambda m: m.genTime)
+
         first_order_results = {
             "packets": self.mutated_state.packets,
             "packetsAtN": self.mutated_state.packetsAtN,
             "messageSeq": self.mutated_state.messageSeq,
-            "messages": self.data_tracking.messages,
+            "messages": messages,
             "delays": self.data_tracking.delays,
             "totalPairs": self.data_tracking.totalPairs,
             "symmetricLinks": self.data_tracking.symmetricLinks,

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -80,8 +80,8 @@ class SimulationResults:
         else:
             self.results["collisionRate"] = np.nan
 
-        if self.results["messageSeq"]["val"] != 0 and conf.NR_NODES - 1 != 0:
-            self.results["nodeReach"] = self.results["nrUseful"]/(self.results["messageSeq"]["val"]*(conf.NR_NODES-1))
+        if self.results["messageSeq"] != 0 and conf.NR_NODES - 1 != 0:
+            self.results["nodeReach"] = self.results["nrUseful"]/(self.results["messageSeq"]*(conf.NR_NODES-1))
         else:
             self.results["nodeReach"] = np.nan
 
@@ -189,7 +189,7 @@ class DiscreteEventSim:
         first_order_results = {
             "packets": self.mutated_state.packets,
             "packetsAtN": self.mutated_state.packetsAtN,
-            "messageSeq": self.mutated_state.messageSeq,
+            "messageSeq": self.mutated_state.messageSeq.peek(),
             "messages": messages,
             "delays": self.data_tracking.delays,
             "totalPairs": self.data_tracking.totalPairs,

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -170,23 +170,15 @@ class DiscreteEventSim:
 
     def get_results(self) -> SimulationResults:
         # TODO: is it possible to add a check that the sim has finished running?
-        # first-order stats/data collection
 
-        # collect messages from each node, put into single sorted list.
-        # This saves a parameter from MeshNode, but arguably adds complexity when
-        # before, each node just appended to the list and it was naturally sorted.
-        # May decide to undo this refactor later.
-        messages = []
-        node_stats = [n.get_stats() for n in self.mutated_state.nodes]
-        for stats in node_stats:
-            messages.extend(stats.messages)
-        messages.sort(key=lambda m: m.genTime)
+        # expect to use this very soon
+        #node_stats = [n.get_stats() for n in self.mutated_state.nodes]
 
         first_order_results = {
             "packets": self.mutated_state.packets,
             "packetsAtN": self.mutated_state.packetsAtN,
             "messageSeq": self.mutated_state.messageSeq.peek(),
-            "messages": messages,
+            "messages": self.data_tracking.messages,
             "delays": self.data_tracking.delays,
             "totalPairs": self.data_tracking.totalPairs,
             "symmetricLinks": self.data_tracking.symmetricLinks,

--- a/lib/discrete_event_sim.py
+++ b/lib/discrete_event_sim.py
@@ -170,7 +170,6 @@ class DiscreteEventSim:
                 self.nodes,
                 self.env,
                 self.mutated_state.bc_pipe,
-                self.conf.PERIOD,
                 self.mutated_state.packetsAtN,
                 self.mutated_state.packets,
                 self.data_tracking.delays,

--- a/lib/discrete_event_sim_components.py
+++ b/lib/discrete_event_sim_components.py
@@ -6,6 +6,30 @@ from lib.discrete_event import BroadcastPipe
 # This is where we put components of DiscreteEventSim that need to be referenced
 # by other classes, to avoid circular imports
 
+class Counter:
+    """simple shared counter, so we have a more ergonomic way to get
+    a strictly increasing integer for message IDs than manually handling an
+    integer. Can add locking later if necessary (very likely won't be).
+    """
+    def __init__(self, start: int=0):
+        """Create a counter
+
+        Arguments:
+        start -- integer to start counter at. First value from 'get' is start+1. Default 0.
+        """
+        self.counter = start
+
+    def get(self):
+        """increment the counter, returning its current value after the increment.
+        """
+        self.counter += 1
+        return self.counter
+
+    def peek(self):
+        """return the current value of the counter. Do not modify the counter
+        """
+        return self.counter
+
 class SimulationState:
     """Class to hold all global mutated state of a simulation, not including
     node-specific state such as the position of a moving node.
@@ -21,7 +45,7 @@ class SimulationState:
         self.bc_pipe = BroadcastPipe(self.env)
         self.packets = [] # used mostly for data tracking, but also for state
         self.packetsAtN = [[] for _ in range(conf.NR_NODES)]
-        self.messageSeq = {"val": 0} # TODO: turn this into a locked counter
+        self.messageSeq = Counter()
 
 class SimulationDataTracking:
     """Class to hold data used to monitor a simulation which has no

--- a/lib/discrete_event_sim_components.py
+++ b/lib/discrete_event_sim_components.py
@@ -1,0 +1,36 @@
+from simpy import Environment as SimpyEnvironment
+
+from lib.config import Config
+from lib.discrete_event import BroadcastPipe
+
+# This is where we put components of DiscreteEventSim that need to be referenced
+# by other classes, to avoid circular imports
+
+class SimulationState:
+    """Class to hold all global mutated state of a simulation, not including
+    node-specific state such as the position of a moving node.
+    """
+    def __init__(self, conf: Config, env: SimpyEnvironment):
+        """Constructor
+
+        Arguments:
+        conf -- Config object of global sim constants. Only used for NR_NODES.
+        env -- SimPy Environment for simulation. Required for internal BroadcastPipe.
+        """
+        self.env = env
+        self.bc_pipe = BroadcastPipe(self.env)
+        self.packets = [] # used mostly for data tracking, but also for state
+        self.packetsAtN = [[] for _ in range(conf.NR_NODES)]
+        self.messageSeq = {"val": 0} # TODO: turn this into a locked counter
+
+class SimulationDataTracking:
+    """Class to hold data used to monitor a simulation which has no
+    impact on the state or progress of the simulation
+    """
+    def __init__(self):
+        self.messages = []
+        self.delays = []
+        self.totalPairs = 0
+        self.symmetricLinks = 0
+        self.asymmetricLinks = 0
+        self.noLinks = 0

--- a/lib/discrete_event_sim_components.py
+++ b/lib/discrete_event_sim_components.py
@@ -46,6 +46,7 @@ class SimulationState:
         self.packets = [] # used mostly for data tracking, but also for state
         self.packetsAtN = [[] for _ in range(conf.NR_NODES)]
         self.messageSeq = Counter()
+        self.nodes = []
 
 class SimulationDataTracking:
     """Class to hold data used to monitor a simulation which has no

--- a/lib/node.py
+++ b/lib/node.py
@@ -108,7 +108,7 @@ class MeshNode:
     """Class containing all the particular state of a MeshNode, references to necessary
     external resources like the simpy env, and process functions for simulation
     """
-    def __init__(self, conf, nodes, sim_state: SimulationState, data_tracking: SimulationDataTracking, nodeConfig: NodeConfig):
+    def __init__(self, conf, sim_state: SimulationState, data_tracking: SimulationDataTracking, nodeConfig: NodeConfig):
         self.conf = conf
         self.nodeid = nodeConfig.node_id
         self.moveRng = random.Random(self.nodeid)
@@ -127,7 +127,7 @@ class MeshNode:
         self.env = sim_state.env
         self.period = nodeConfig.period
         self.bc_pipe = sim_state.bc_pipe
-        self.nodes = nodes
+        self.nodes = sim_state.nodes
         self.packetsAtN = sim_state.packetsAtN
         self.nrPacketsSent = 0
         self.packets = sim_state.packets

--- a/lib/node.py
+++ b/lib/node.py
@@ -122,11 +122,11 @@ class MeshNode:
         self.channelUtilizationIndex = 0  # which "bucket" is current
         self.prevTxAirUtilization = 0.0   # how much total tx air-time had been used at last sample
 
-        env.process(self.track_channel_utilization(env))
+        self.env.process(self.track_channel_utilization())
         if not self.is_repeater:  # repeaters don't generate messages themselves
-            env.process(self.generate_message())
-        env.process(self.receive(self.bc_pipe.get_output_conn()))
-        self.transmitter = simpy.Resource(env, 1)
+            self.env.process(self.generate_message())
+        self.env.process(self.receive(self.bc_pipe.get_output_conn()))
+        self.transmitter = simpy.Resource(self.env, 1)
 
         # start mobility if enabled
         if self.conf.MOVEMENT_ENABLED and self.moveRng.random() <= self.conf.APPROX_RATIO_NODES_MOVING:
@@ -142,7 +142,7 @@ class MeshNode:
             ]
             self.movementStepSize = self.moveRng.choice(possibleSpeeds)
 
-            env.process(self.move_node(env))
+            self.env.process(self.move_node())
 
     @property
     def is_router(self):
@@ -156,14 +156,14 @@ class MeshNode:
     def is_client_mute(self):
         return self.role == MESHTASTIC_ROLE.CLIENT_MUTE
 
-    def track_channel_utilization(self, env):
+    def track_channel_utilization(self):
         """
         Periodically compute how many seconds of airtime this node consumed
         over the last 10-second block and store it in the ring buffer.
         """
         while True:
             # Wait 10 seconds of simulated time
-            yield env.timeout(self.conf.TEN_SECONDS_INTERVAL)
+            yield self.env.timeout(self.conf.TEN_SECONDS_INTERVAL)
 
             curTotalAirtime = self.txAirUtilization  # total so far, in *milliseconds*
             blockAirtimeMs = curTotalAirtime - self.prevTxAirUtilization
@@ -182,7 +182,7 @@ class MeshNode:
         # fraction = sum_ms / 60000, then multiply by 100 for percent
         return (sumMs / (self.conf.CHANNEL_UTILIZATION_PERIODS * self.conf.TEN_SECONDS_INTERVAL)) * 100.0
 
-    def move_node(self, env):
+    def move_node(self):
         while True:
 
             # Pick a random direction and distance
@@ -208,20 +208,20 @@ class MeshNode:
             if self.gpsEnabled:
                 distanceTraveled = self.position.euclidean_distance(self.lastBroadcastPosition)
                 logger.debug(f"{self.env.now:.3f} node {self.nodeid} checks last broadcast position distance: {distanceTraveled} from {self.lastBroadcastPosition} to {self.position}")
-                timeElapsed = env.now - self.lastBroadcastTime
+                timeElapsed = self.env.now - self.lastBroadcastTime
                 if distanceTraveled >= self.conf.SMART_POSITION_DISTANCE_THRESHOLD and timeElapsed >= self.conf.SMART_POSITION_DISTANCE_MIN_TIME:
                     currentUtil = self.channel_utilization_percent()
                     if currentUtil < 25.0:
                         self.send_packet(NODENUM_BROADCAST, "POSITION")
                         self.lastBroadcastPosition.update_xy(self.position.x, self.position.y)
-                        self.lastBroadcastTime = env.now
+                        self.lastBroadcastTime = self.env.now
                     else:
                         logger.debug(f"{self.env.now:.3f} node {self.nodeid} SKIPS POSITION broadcast (util={currentUtil:.1f}% > 25%)")
 
             # Wait until next move
             nextMove = self.get_next_time(self.conf.ONE_MIN_INTERVAL)
             if nextMove >= 0:
-                yield env.timeout(nextMove)
+                yield self.env.timeout(nextMove)
             else:
                 break
 

--- a/lib/node.py
+++ b/lib/node.py
@@ -32,6 +32,31 @@ class MESHTASTIC_ROLE(Enum):
     ROUTER_LATE = 'ROUTER_LATE'
     CLIENT_BASE = 'CLIENT_BASE'
 
+class MeshNodeStats:
+    """Statistics, monitoring, and data tracking only relevant to and entirely
+    internal to a single particular node
+    """
+
+    def __init__(self, nodeid: int):
+        self.nodeid = nodeid
+        self.messages = []
+
+    def add_message(self, m: MeshMessage):
+        """We have created a new message in the sim, either original or ack.
+        Add it to list of messages we've created
+        """
+        self.messages.append(m)
+
+    def get_stats_dictionary(self) -> dict:
+        """Return dictionary holding all internal data
+        (may not need this)
+        """
+        data = {
+            "nodeid": self.nodeid,
+            "messages": self.messages,
+        }
+        return data
+
 class NodeConfig:
     """Specific configuration for a node
     """
@@ -81,7 +106,7 @@ class MeshNode:
     """Class containing all the particular state of a MeshNode, references to necessary
     external resources like the simpy env, and process functions for simulation
     """
-    def __init__(self, conf, nodes, env, bc_pipe, period, messages, packetsAtN, packets, delays, nodeConfig: NodeConfig, messageSeq):
+    def __init__(self, conf, nodes, env, bc_pipe, period, packetsAtN, packets, delays, nodeConfig: NodeConfig, messageSeq):
         self.conf = conf
         self.nodeid = nodeConfig.node_id
         self.moveRng = random.Random(self.nodeid)
@@ -94,12 +119,13 @@ class MeshNode:
         self.hopLimit = nodeConfig.hop_limit
         self.antennaGain = nodeConfig.antenna_gain
 
+        self.my_stats = MeshNodeStats(self.nodeid)
+
         self.messageSeq = messageSeq
         self.env = env
         self.period = period
         self.bc_pipe = bc_pipe
         self.nodes = nodes
-        self.messages = messages
         self.packetsAtN = packetsAtN
         self.nrPacketsSent = 0
         self.packets = packets
@@ -231,7 +257,7 @@ class MeshNode:
         # increment the shared counter
         self.messageSeq["val"] += 1
         messageSeq = self.messageSeq["val"]
-        self.messages.append(MeshMessage(self.nodeid, destId, self.env.now, messageSeq))
+        self.my_stats.add_message(MeshMessage(self.nodeid, destId, self.env.now, messageSeq))
         p = MeshPacket(self.conf, self.nodes, self.nodeid, destId, self.nodeid, self.conf.PACKETLENGTH, messageSeq, self.env.now, True, False, None, self.env.now)
         logger.debug(f"{self.env.now:.3f} Node {self.nodeid} generated {type} message {p.seq} to {destId}")
         self.packets.append(p)
@@ -399,7 +425,7 @@ class MeshNode:
                     logger.debug(f"{self.env.now:.3f} Node {self.nodeid} sends a flooding ACK.")
                     self.messageSeq["val"] += 1
                     messageSeq = self.messageSeq["val"]
-                    self.messages.append(MeshMessage(self.nodeid, p.origTxNodeId, self.env.now, messageSeq))
+                    self.my_stats.add_message(MeshMessage(self.nodeid, p.origTxNodeId, self.env.now, messageSeq))
                     pAck = MeshPacket(self.conf, self.nodes, self.nodeid, p.origTxNodeId, self.nodeid, self.conf.ACKLENGTH, messageSeq, self.env.now, False, True, p.seq, self.env.now)
                     self.packets.append(pAck)
                     self.env.process(self.transmit(pAck))
@@ -415,6 +441,11 @@ class MeshNode:
                             self.env.process(self.transmit(pNew))
                 else:
                     self.droppedByDelay += 1
+
+    def get_stats(self) -> MeshNodeStats:
+        """Get internally-tracked statistics/data. Only valid after the sim ends.
+        """
+        return self.my_stats
 
 def default_generate_node_list(conf: Config) -> [NodeConfig]:
     """Default function for randomly choosing node configurations for a simulation

--- a/lib/node.py
+++ b/lib/node.py
@@ -60,16 +60,17 @@ class MeshNodeStats:
 class NodeConfig:
     """Specific configuration for a node
     """
-    def __init__(self, node_id: int, position: Point, role: MESHTASTIC_ROLE = MESHTASTIC_ROLE.CLIENT, antenna_gain: float = 0, hop_limit: int = 3, neighbor_info: bool = False):
+    def __init__(self, node_id: int, position: Point, period: int, role: MESHTASTIC_ROLE = MESHTASTIC_ROLE.CLIENT, antenna_gain: float = 0, hop_limit: int = 3, neighbor_info: bool = False):
         self.node_id = node_id
         self.position = position.copy() # make sure we keep our own point
+        self.period = period
         self.role = role
         self.antenna_gain = antenna_gain
         self.hop_limit = hop_limit
         self.neighbor_info = neighbor_info
 
     @classmethod
-    def from_gen_scenario_output(cls, node_id: int, node_dict: {}):
+    def from_gen_scenario_output(cls, node_id: int, node_dict: {}, period: int):
         """create NodeConfig from a node dict as returned from gen_scenario.
         You probably want to iterate over the keys that function gives you
         and pass individual values indexed by them to this method.
@@ -100,13 +101,13 @@ class NodeConfig:
         else:
             role = MESHTASTIC_ROLE.CLIENT
 
-        return NodeConfig(node_id, position, role, nd['antennaGain'], nd['hopLimit'], nd['neighborInfo'])
+        return NodeConfig(node_id, position, period, role, nd['antennaGain'], nd['hopLimit'], nd['neighborInfo'])
 
 class MeshNode:
     """Class containing all the particular state of a MeshNode, references to necessary
     external resources like the simpy env, and process functions for simulation
     """
-    def __init__(self, conf, nodes, env, bc_pipe, period, packetsAtN, packets, delays, nodeConfig: NodeConfig, messageSeq):
+    def __init__(self, conf, nodes, env, bc_pipe, packetsAtN, packets, delays, nodeConfig: NodeConfig, messageSeq):
         self.conf = conf
         self.nodeid = nodeConfig.node_id
         self.moveRng = random.Random(self.nodeid)
@@ -123,7 +124,7 @@ class MeshNode:
 
         self.messageSeq = messageSeq
         self.env = env
-        self.period = period
+        self.period = nodeConfig.period
         self.bc_pipe = bc_pipe
         self.nodes = nodes
         self.packetsAtN = packetsAtN
@@ -481,6 +482,6 @@ def default_generate_node_list(conf: Config) -> [NodeConfig]:
             role = MESHTASTIC_ROLE.CLIENT
 
         # make NodeConfig object to pass to MeshNode constructor
-        node_configs.append(NodeConfig(i, position, role))
+        node_configs.append(NodeConfig(i, position, conf.PERIOD, role))
 
     return node_configs

--- a/lib/node.py
+++ b/lib/node.py
@@ -40,13 +40,6 @@ class MeshNodeStats:
 
     def __init__(self, nodeid: int):
         self.nodeid = nodeid
-        self.messages = []
-
-    def add_message(self, m: MeshMessage):
-        """We have created a new message in the sim, either original or ack.
-        Add it to list of messages we've created
-        """
-        self.messages.append(m)
 
     def get_stats_dictionary(self) -> dict:
         """Return dictionary holding all internal data
@@ -54,7 +47,6 @@ class MeshNodeStats:
         """
         data = {
             "nodeid": self.nodeid,
-            "messages": self.messages,
         }
         return data
 
@@ -111,6 +103,8 @@ class MeshNode:
     def __init__(self, conf, sim_state: SimulationState, data_tracking: SimulationDataTracking, nodeConfig: NodeConfig):
         self.conf = conf
         self.nodeid = nodeConfig.node_id
+
+        # set up internal RNGs
         self.moveRng = random.Random(self.nodeid)
         self.nodeRng = random.Random(self.nodeid)
         self.rebroadcastRng = random.Random()
@@ -120,18 +114,21 @@ class MeshNode:
         self.role = nodeConfig.role
         self.hopLimit = nodeConfig.hop_limit
         self.antennaGain = nodeConfig.antenna_gain
+        self.period = nodeConfig.period
 
         self.my_stats = MeshNodeStats(self.nodeid)
 
         self.messageSeq = sim_state.messageSeq
         self.env = sim_state.env
-        self.period = nodeConfig.period
         self.bc_pipe = sim_state.bc_pipe
         self.nodes = sim_state.nodes
         self.packetsAtN = sim_state.packetsAtN
-        self.nrPacketsSent = 0
         self.packets = sim_state.packets
+
         self.delays = data_tracking.delays
+        self.messages = data_tracking.messages
+
+        self.nrPacketsSent = 0
         self.timesReceived = {}
         self.isReceiving = []
         self.isTransmitting = False
@@ -142,9 +139,11 @@ class MeshNode:
         self.rebroadcastPackets = 0
         self.isMoving = False
         self.gpsEnabled = False
+
         # Track last broadcast position/time
         self.lastBroadcastPosition = self.position.copy()
         self.lastBroadcastTime = 0
+
         # track total transmit time for the last 6 buckets (each is 10s in firmware logic)
         self.channelUtilization = [0] * self.conf.CHANNEL_UTILIZATION_PERIODS  # each entry is ms spent on air in that interval
         self.channelUtilizationIndex = 0  # which "bucket" is current
@@ -258,7 +257,7 @@ class MeshNode:
         """
         # increment the shared counter
         messageSeq = self.messageSeq.get()
-        self.my_stats.add_message(MeshMessage(self.nodeid, destId, self.env.now, messageSeq))
+        self.messages.append(MeshMessage(self.nodeid, destId, self.env.now, messageSeq))
         p = MeshPacket(self.conf, self.nodes, self.nodeid, destId, self.nodeid, self.conf.PACKETLENGTH, messageSeq, self.env.now, True, False, None, self.env.now)
         logger.debug(f"{self.env.now:.3f} Node {self.nodeid} generated {type} message {p.seq} to {destId}")
         self.packets.append(p)
@@ -425,7 +424,7 @@ class MeshNode:
                 if p.wantAck and p.destId == self.nodeid and not any(pA.requestId == p.seq for pA in self.packets):
                     logger.debug(f"{self.env.now:.3f} Node {self.nodeid} sends a flooding ACK.")
                     messageSeq = self.messageSeq.get()
-                    self.my_stats.add_message(MeshMessage(self.nodeid, p.origTxNodeId, self.env.now, messageSeq))
+                    self.messages.append(MeshMessage(self.nodeid, p.origTxNodeId, self.env.now, messageSeq))
                     pAck = MeshPacket(self.conf, self.nodes, self.nodeid, p.origTxNodeId, self.nodeid, self.conf.ACKLENGTH, messageSeq, self.env.now, False, True, p.seq, self.env.now)
                     self.packets.append(pAck)
                     self.env.process(self.transmit(pAck))

--- a/lib/node.py
+++ b/lib/node.py
@@ -257,8 +257,7 @@ class MeshNode:
         """We have created a new message and wish to send it to the network
         """
         # increment the shared counter
-        self.messageSeq["val"] += 1
-        messageSeq = self.messageSeq["val"]
+        messageSeq = self.messageSeq.get()
         self.my_stats.add_message(MeshMessage(self.nodeid, destId, self.env.now, messageSeq))
         p = MeshPacket(self.conf, self.nodes, self.nodeid, destId, self.nodeid, self.conf.PACKETLENGTH, messageSeq, self.env.now, True, False, None, self.env.now)
         logger.debug(f"{self.env.now:.3f} Node {self.nodeid} generated {type} message {p.seq} to {destId}")
@@ -425,8 +424,7 @@ class MeshNode:
                 # send real ACK if you are the destination and you did not yet send the ACK
                 if p.wantAck and p.destId == self.nodeid and not any(pA.requestId == p.seq for pA in self.packets):
                     logger.debug(f"{self.env.now:.3f} Node {self.nodeid} sends a flooding ACK.")
-                    self.messageSeq["val"] += 1
-                    messageSeq = self.messageSeq["val"]
+                    messageSeq = self.messageSeq.get()
                     self.my_stats.add_message(MeshMessage(self.nodeid, p.origTxNodeId, self.env.now, messageSeq))
                     pAck = MeshPacket(self.conf, self.nodes, self.nodeid, p.origTxNodeId, self.nodeid, self.conf.ACKLENGTH, messageSeq, self.env.now, False, True, p.seq, self.env.now)
                     self.packets.append(pAck)

--- a/lib/node.py
+++ b/lib/node.py
@@ -8,6 +8,7 @@ import simpy
 
 from lib.common import find_random_position
 from lib.config import Config
+from lib.discrete_event_sim_components import SimulationState, SimulationDataTracking
 from lib.mac import set_transmit_delay, get_retransmission_msec
 from lib.phy import check_collision, is_channel_active, airtime
 from lib.packet import NODENUM_BROADCAST, MeshPacket, MeshMessage
@@ -107,7 +108,7 @@ class MeshNode:
     """Class containing all the particular state of a MeshNode, references to necessary
     external resources like the simpy env, and process functions for simulation
     """
-    def __init__(self, conf, nodes, env, bc_pipe, packetsAtN, packets, delays, nodeConfig: NodeConfig, messageSeq):
+    def __init__(self, conf, nodes, sim_state: SimulationState, data_tracking: SimulationDataTracking, nodeConfig: NodeConfig):
         self.conf = conf
         self.nodeid = nodeConfig.node_id
         self.moveRng = random.Random(self.nodeid)
@@ -122,15 +123,15 @@ class MeshNode:
 
         self.my_stats = MeshNodeStats(self.nodeid)
 
-        self.messageSeq = messageSeq
-        self.env = env
+        self.messageSeq = sim_state.messageSeq
+        self.env = sim_state.env
         self.period = nodeConfig.period
-        self.bc_pipe = bc_pipe
+        self.bc_pipe = sim_state.bc_pipe
         self.nodes = nodes
-        self.packetsAtN = packetsAtN
+        self.packetsAtN = sim_state.packetsAtN
         self.nrPacketsSent = 0
-        self.packets = packets
-        self.delays = delays
+        self.packets = sim_state.packets
+        self.delays = data_tracking.delays
         self.timesReceived = {}
         self.isReceiving = []
         self.isTransmitting = False

--- a/lib/node.py
+++ b/lib/node.py
@@ -226,6 +226,8 @@ class MeshNode:
                 break
 
     def send_packet(self, destId, type=""):
+        """We have created a new message and wish to send it to the network
+        """
         # increment the shared counter
         self.messageSeq["val"] += 1
         messageSeq = self.messageSeq["val"]

--- a/lib/packet.py
+++ b/lib/packet.py
@@ -5,6 +5,22 @@ NODENUM_BROADCAST = 0xFFFFFFFF
 
 class MeshPacket:
     def __init__(self, conf, nodes, origTxNodeId, destId, txNodeId, plen, seq, genTime, wantAck, isAck, requestId, now):
+        """Create a new packet and calculate which nodes sense and receive it
+
+        Arguments:
+        conf -- simulation Config
+        nodes -- set of all nodes in the simulation. For calculating which nodes receive the packet
+        origTxNodeId -- ID of originating node
+        destId -- ID of destination node (specific node or broadcast)
+        txNodeId -- ID of currently transmitting node
+        plen -- packet length
+        seq -- message sequence number
+        genTime -- sim time of original packet generation (different from acks/rebroadcasts)
+        wantAck -- this packet wants an ACK
+        isAck -- this packet is an ACK packet
+        requestId -- ID of packet requesting ACK (only valid for ACK packets)
+        now -- current sim time when called, always `env.now`
+        """
         self.conf = conf
         self.origTxNodeId = origTxNodeId
         self.destId = destId
@@ -30,6 +46,7 @@ class MeshPacket:
         self.bw = self.conf.current_preset["bw"]
         self.freq = self.conf.FREQ
         self.tx_node = next(n for n in nodes if n.nodeid == self.txNodeId)
+        # calculate reception at all other nodes
         for rx_node in nodes:
             if rx_node.nodeid == self.txNodeId:
                 continue

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -72,7 +72,7 @@ def parse_params(conf, args) -> [NodeConfig]:
         config = default_generate_node_list(conf)
     else:
         config_dict = gen_scenario(conf)
-        config = [NodeConfig.from_gen_scenario_output(node_id, cfg) for node_id, cfg in config_dict.items()]
+        config = [NodeConfig.from_gen_scenario_output(node_id, cfg, conf.PERIOD) for node_id, cfg in config_dict.items()]
         conf.NR_NODES = len(config)
 
     if conf.NR_NODES < 2:

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -127,7 +127,7 @@ delayDropped = results['delayDropped']
 
 print("*******************************")
 print(f"\nRouter Type: {conf.SELECTED_ROUTER_TYPE}")
-print('Number of messages created:', messageSeq["val"])
+print('Number of messages created:', messageSeq)
 print('Number of packets sent:', sent, 'to', potentialReceivers, 'potential receivers')
 print("Number of collisions:", nrCollisions)
 print("Number of packets sensed:", nrSensed)

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -43,7 +43,7 @@ class TestDiscreteEventSim(unittest.TestCase):
         # - nodes (list of nodes)
         # - packets (list of packets)
         # - delays (list of ...floats?)
-        # - messageSeq["val"] - total # of messages
+        # - messageSeq - total # of messages
         # - totalPairs (int)
         # - asymmetricLinks (int)
         # - symmetricLinks (int)
@@ -110,7 +110,7 @@ class TestDiscreteEventSim(unittest.TestCase):
         r['nodes'] = mock_nodes
         r['packets'] = mock_packets
         r['delays'] = [1.0 for _ in range(10)]
-        r['messageSeq'] = {'val': 10} # total # of messages (not packets)
+        r['messageSeq'] = 10 # total # of messages (not packets)
 
         # as set up, totalPairs = symmetricLinks + asymmetricLinks + noLinks
         r['totalPairs'] = 3
@@ -201,7 +201,7 @@ class TestDiscreteEventSim(unittest.TestCase):
         # and modify your changes, or to update the hardcoded "known good"
         # simulation results is up to your judgement for which is
         # appropriate. Be cautious!
-        self.assertEqual(messageSeq["val"], 180, "expected number of messages created")
+        self.assertEqual(messageSeq, 180, "expected number of messages created")
         sent = results['sent']
         potentialReceivers = results['potentialReceivers']
         self.assertEqual(sent, 875, "expected number of packets sent")

--- a/tests/test_discrete_event_sim_components.py
+++ b/tests/test_discrete_event_sim_components.py
@@ -1,0 +1,32 @@
+import unittest
+
+import lib.discrete_event_sim_components as dsc
+
+class TestDiscreteSimComponents(unittest.TestCase):
+    '''Mostly sanity-checking of very simple sim components
+    '''
+
+    # If other classes get more complex than simple bundles of data, add tests
+
+    def test_counter(self):
+        '''counter sanity tests
+        '''
+        c = dsc.Counter()
+
+        self.assertEqual(c.peek(), 0, 'expected default counter start')
+
+        n = c.get()
+        self.assertEqual(n, 1, 'expected first sequence number')
+
+        c.get()
+        c.get()
+        n = c.get()
+        self.assertEqual(n, 4, 'expected counter increases')
+
+        n = c.peek()
+        self.assertEqual(n, 4, 'peeking does not change counter value, and returns correct value')
+
+        c = dsc.Counter(10)
+        n = c.get()
+        self.assertEqual(n, 11, 'can change default start')
+


### PR DESCRIPTION
This should handle issue #58. I didn't move as much stat tracking to be internal to the node as I first thought because more of that seems to fit with #50 and other optimizations, and putting `messages` in there wound up being somewhat more complicated (imo) with no benefit. The sim appears to be deterministic and single-threaded with only one process running at a time, so many nodes appending to a single shared list doesn't actually seem to be a problem. Additionally, keeping message lists in each node that generated them means we have to collect and sort them later, which is less efficient and just gives us an unnecessary small thing to maintain.

I keep the MeshNodeStats object around because I foresee putting other stats in there in the future, like refactoring the calculation of `nrCollisions` and `nrSensed`. That will probably be in #50 and afterwards may make more sense moved into SimulationDataTracking anyways, but I didn't want to delete it just to re-create it later. Besides, I can imagine a use-case for keeping node-specific stats separate from the big pool of global sim stats & data.