### PR TITLE
Move collision check when first receiving packet to fix 'double-count'

### DIFF
--- a/lib/node.py
+++ b/lib/node.py
@@ -372,8 +372,14 @@ class MeshNode:
     def receive(self, in_pipe):
         while True:
             p = yield in_pipe.get()
-            if p.sensedByN[self.nodeid] and not p.collidedAtN[self.nodeid] and p.onAirToN[self.nodeid]:  # start of reception
-                if not self.isTransmitting:
+
+            if p.sensedByN[self.nodeid] and p.onAirToN[self.nodeid]:  # start of reception
+                if p.collidedAtN[self.nodeid]:
+                    # this packet collided, so we can sense it but not decode it.
+                    # Mark it as no-longer on air and leave further processing to
+                    # the 'end of transmission' branch
+                    p.onAirToN[self.nodeid] = False
+                elif not self.isTransmitting:
                     logger.debug(f"{self.env.now:.3f} Node {self.nodeid} started receiving packet {p.seq} from {p.txNodeId}")
                     p.onAirToN[self.nodeid] = False
                     self.isReceiving.append(True)


### PR DESCRIPTION
Before, we would hit the 'transmission finished' branch twice if a packet is colliding when we first hear it, and never hit the 'transmission begins' branch.  this moves the check so that we hit each branch once. More discussion in #65 .