### PR TITLE
test(ci): run unit tests in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/tests/test_discrete_event_sim.py
+++ b/tests/test_discrete_event_sim.py
@@ -201,32 +201,32 @@ class TestDiscreteEventSim(unittest.TestCase):
         # and modify your changes, or to update the hardcoded "known good"
         # simulation results is up to your judgement for which is
         # appropriate. Be cautious!
-        self.assertEqual(messageSeq, 180, "expected number of messages created")
+        self.assertEqual(messageSeq, 183, "expected number of messages created")
         sent = results['sent']
         potentialReceivers = results['potentialReceivers']
-        self.assertEqual(sent, 875, "expected number of packets sent")
-        self.assertEqual(potentialReceivers, 7875, "expected number of potential receivers")
+        self.assertEqual(sent, 895, "expected number of packets sent")
+        self.assertEqual(potentialReceivers, 8055, "expected number of potential receivers")
 
         nrCollisions = results['nrCollisions']
-        self.assertEqual(nrCollisions, 320, "expected number of collisions")
+        self.assertEqual(nrCollisions, 332, "expected number of collisions")
         nrSensed = results['nrSensed']
-        self.assertEqual(nrSensed, 3071, "expected number of packets sensed")
+        self.assertEqual(nrSensed, 3173, "expected number of packets sensed")
 
         nrReceived = results['nrReceived']
-        self.assertEqual(nrReceived, 2743, "expected number of packets received")
+        self.assertEqual(nrReceived, 2824, "expected number of packets received")
         meanDelay = results['meanDelay']
-        self.assertEqual(round(meanDelay, 2), 9465.81, "expected rounded delay average")
+        self.assertEqual(round(meanDelay, 2), 11174.95, "expected rounded delay average")
         txAirUtilizationRate = results['txAirUtilizationRate']
-        self.assertEqual(round(txAirUtilizationRate * 100, 2), 5.06, "expected rounded average tx air utilization")
+        self.assertEqual(round(txAirUtilizationRate * 100, 2), 5.15, "expected rounded average tx air utilization")
 
         nodeReach = results['nodeReach']
-        self.assertEqual(round(nodeReach*100, 2), 85.06, "expected rounded percentage of nodes reached")
+        self.assertEqual(round(nodeReach*100, 2), 85.55, "expected rounded percentage of nodes reached")
 
         usefulness = results['usefulness']
-        self.assertEqual(round(usefulness*100, 2), 50.24, "expected rounded 'usefulness' percentage")
+        self.assertEqual(round(usefulness*100, 2), 49.89, "expected rounded 'usefulness' percentage")
 
         delayDropped = results['delayDropped']
-        self.assertEqual(delayDropped, 1255, "expected number of packets dropped")
+        self.assertEqual(delayDropped, 1280, "expected number of packets dropped")
         # default config has both asymmetric links and movement enabled
         asymmetricLinkRate = results['asymmetricLinkRate']
         self.assertEqual(round(asymmetricLinkRate * 100, 2), 8.89, "expected rounded percentage of asymmetric links")

--- a/tests/test_lora_mesh_cli.py
+++ b/tests/test_lora_mesh_cli.py
@@ -168,6 +168,7 @@ class TestLoraMeshCli(unittest.TestCase):
             """
         )
 
+        os.makedirs("out", exist_ok=True)
         with tempfile.NamedTemporaryFile("w", dir="out", suffix=".yaml", delete=False, encoding="utf-8") as scenario_file:
             scenario_file.write(scenario)
             scenario_filename = os.path.basename(scenario_file.name)


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs `requirements.txt` and runs `python -m unittest discover -s tests -v` on pull requests and branch pushes
- refresh the deterministic ten-node simulation golden values to match the current `master` behavior after the CLI/import hygiene changes
- make the CLI `--from-file` regression test create its `out/` directory explicitly so clean checkouts can run the suite

## Why
The repository currently has no CI coverage for its unit tests, and a clean `master` checkout was already failing locally: the simulation golden values were stale, and one test assumed an `out/` directory existed. That made later PR validation depend on local context instead of a reproducible GitHub check.

## Validation
- `/tmp/meshtasticator-pr68-venv/bin/python -m unittest discover -s tests -v`
- workflow trigger smoke: checked `.github/workflows/tests.yml` contains `pull_request` and branch `push` triggers
- fork GitHub Actions run: https://github.com/Komzpa/Meshtasticator/actions/runs/25284537678 (`Tests / unittest`, success)
- `git diff --check`

Note: the workflow uses Python 3.11 because the current `requirements.txt` includes `pandas==1.5.3`, which is a safer CI target on 3.11 than on newest Python releases.
