### PR TITLE
chore(deps): update scientific Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 meshtastic~=2.6.1
-numpy==1.26.4
-matplotlib==3.10.0
-pandas==1.5.3
+numpy~=2.2.6
+matplotlib~=3.10.0
+pandas~=2.2.3
 PyPubSub==4.0.3
 simpy==4.1.1
 PyYAML~=6.0.2


### PR DESCRIPTION
## Summary
- update the old scientific package pins so modern Python can install binary wheels instead of trying to build stale pandas/numpy releases
- keep the change conservative: pandas stays on the 2.2 series, numpy on the 2.2 series, and matplotlib on 3.10 patch releases

Fixes #51.

## Validation
- `python3 -m venv /tmp/meshtasticator-req-venv`
- `/tmp/meshtasticator-req-venv/bin/python -m pip install -r requirements.txt`
  - installed `numpy 2.2.6`, `pandas 2.2.3`, `matplotlib 3.10.9`, `meshtastic 2.6.4`, `protobuf 4.25.9`
- `MPLBACKEND=Agg /tmp/meshtasticator-req-venv/bin/python -m unittest discover -s tests -v`
  - 20 tests OK
