### PR TITLE
fix(interactive): avoid hanging on interface close

### DIFF
--- a/lib/interactive.py
+++ b/lib/interactive.py
@@ -20,6 +20,7 @@ from lib.config import Config
 import lib.phy as phy
 from lib.common import find_random_position
 from lib.gui import gen_scenario, Graph
+from lib.interface_close import InterfaceCloseTimeout, close_interface
 from lib.point import Point
 
 logger = logging.getLogger(__name__)
@@ -237,24 +238,24 @@ class InteractiveGraph(Graph):
                     if p.packet["from"] == tx.hwId:
                         if "requestId" in p.packet["decoded"]:
                             if p.packet["priority"] == "ACK":
-                                msgType = "Real\/ACK"
+                                msgType = r"Real\/ACK"
                             else:
                                 msgType = "Response"
                         else:
                             msgType = "Original message"
                     elif "requestId" in p.packet["decoded"]:
                         if p.packet["decoded"]["simulator"]["portnum"] == "ROUTING_APP":
-                            msgType = "Forwarding\/real\/ACK"
+                            msgType = r"Forwarding\/real\/ACK"
                         else:
-                            msgType = "Forwarding\/response"
+                            msgType = r"Forwarding\/response"
                     else:
                         if int(p.packet['from']) == rx.hwId:
-                            msgType = "Implicit\/ACK"
+                            msgType = r"Implicit\/ACK"
                         else:
                             if to == "All":
                                 msgType = "Rebroadcast"
                             else:
-                                msgType = "Forwarding\/message"
+                                msgType = r"Forwarding\/message"
 
                     hopLimit = p.packet.get("hopLimit")
 
@@ -520,10 +521,13 @@ class InteractiveSim:
         time.sleep(3)
         for n in self.nodes[int(self.forwardToClient):]:
             try:
-                n.iface.close()
-                n.iface = None
+                close_interface(n.iface)
             except OSError:
                 pass
+            except InterfaceCloseTimeout as ex:
+                print(f"Warning: node {n.nodeid} interface close timed out during reconnect ({ex}).")
+            finally:
+                n.iface = None
         time.sleep(5)
         for n in self.nodes:
             while not n.iface:
@@ -749,7 +753,10 @@ class InteractiveSim:
         pub.unsubAll()
         for n in self.nodes:
             n.iface.localNode.exitSimulator()
-            n.iface.close()
+            try:
+                close_interface(n.iface)
+            except InterfaceCloseTimeout as ex:
+                print(f"Warning: node {n.nodeid} interface close timed out during shutdown ({ex}).")
         if self.docker:
             self.container.stop()
         if self.forwardToClient:

--- a/lib/interface_close.py
+++ b/lib/interface_close.py
@@ -1,0 +1,36 @@
+import threading
+
+
+IFACE_CLOSE_TIMEOUT_SECONDS = 5
+
+
+class InterfaceCloseTimeout(TimeoutError):
+    """Raised when a Meshtastic TCP interface does not finish closing."""
+
+
+def close_interface(iface, timeout=IFACE_CLOSE_TIMEOUT_SECONDS):
+    """Close a Meshtastic interface without letting its reader thread hang forever.
+
+    Native meshtasticd setups can block inside `TCPInterface.close()` while the
+    Python Meshtastic client waits for its RX thread to exit. Closing in a daemon
+    helper thread keeps simulator startup/shutdown responsive and lets reconnect
+    continue with a fresh interface.
+    """
+    if iface is None:
+        return
+
+    errors = []
+
+    def run_close():
+        try:
+            iface.close()
+        except Exception as ex:
+            errors.append(ex)
+
+    close_thread = threading.Thread(target=run_close, daemon=True)
+    close_thread.start()
+    close_thread.join(timeout)
+    if close_thread.is_alive():
+        raise InterfaceCloseTimeout(f"interface close did not finish within {timeout:g}s")
+    if errors:
+        raise errors[0]

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,50 @@
+import threading
+import unittest
+
+from lib.interface_close import InterfaceCloseTimeout, close_interface
+
+
+class TestInteractiveInterfaceClose(unittest.TestCase):
+    def test_close_interface_calls_close(self):
+        class Interface:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        iface = Interface()
+
+        close_interface(iface, timeout=0.5)
+
+        self.assertTrue(iface.closed)
+
+    def test_close_interface_preserves_close_errors(self):
+        class Interface:
+            def close(self):
+                raise OSError("socket already gone")
+
+        with self.assertRaisesRegex(OSError, "socket already gone"):
+            close_interface(Interface(), timeout=0.5)
+
+    def test_close_interface_times_out_on_hung_reader_thread(self):
+        class Interface:
+            def __init__(self):
+                self.started = threading.Event()
+                self.release = threading.Event()
+
+            def close(self):
+                self.started.set()
+                self.release.wait(5)
+
+        iface = Interface()
+
+        try:
+            with self.assertRaisesRegex(InterfaceCloseTimeout, "0.01s"):
+                close_interface(iface, timeout=0.01)
+            self.assertTrue(iface.started.is_set())
+        finally:
+            iface.release.set()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- close Meshtastic TCP interfaces through a bounded helper so reconnect/shutdown cannot hang forever inside `TCPInterface.close()`
- keep OSError behavior unchanged, but warn and continue if the close thread does not finish before the timeout
- add focused tests for successful close, propagated close errors, and a hung close path

Refs #35.

## Validation
- `MPLBACKEND=Agg /tmp/meshtasticator-req-venv/bin/python -m unittest tests.test_interactive -v`
  - 3 tests OK
- `MPLBACKEND=Agg /tmp/meshtasticator-req-venv/bin/python -m unittest discover -s tests -v`
  - 23 tests OK
- `git diff --check`
