### PR TITLE
Fix missing tx_power and freq parameters for node configuration

### DIFF
--- a/batchSim.py
+++ b/batchSim.py
@@ -232,7 +232,15 @@ for rt_i, routerType in enumerate(routerTypes):
                 x, y = coords[nodeId]
 
                 # We create a NodeConfig object so that MeshNode will use that
-                nodeConfig = NodeConfig(nodeId, Point(x, y, routerTypeConf.HM), routerTypeConf.PERIOD, antenna_gain=routerTypeConf.GL, hop_limit=routerTypeConf.hopLimit)
+                nodeConfig = NodeConfig(
+                    node_id=nodeId, 
+                    position=Point(x, y, routerTypeConf.HM), 
+                    period=routerTypeConf.PERIOD, 
+                    tx_power=routerTypeConf.PTX, 
+                    freq=routerTypeConf.FREQ, 
+                    antenna_gain=routerTypeConf.GL, 
+                    hop_limit=routerTypeConf.hopLimit
+                    )
                 node_configs.append(nodeConfig)
 
             if SHOW_GRAPH:

--- a/loraMesh.py
+++ b/loraMesh.py
@@ -129,7 +129,7 @@ def parse_params(conf, args=None) -> [NodeConfig]:
         from lib.gui import gen_scenario
 
         config_dict = gen_scenario(conf)
-        config = [NodeConfig.from_gen_scenario_output(node_id, cfg, period) for node_id, cfg in config_dict.items()]
+        config = [NodeConfig.from_gen_scenario_output(node_id, cfg, period, conf.PTX, conf.FREQ) for node_id, cfg in config_dict.items()]
         nr_nodes = len(config)
 
     if nr_nodes < 2:


### PR DESCRIPTION
Using both loraMesh.py and batchSim.py with the default invocation on the latest version could throw a similar TypeError for both files, as the required tx_power and freq arguments were not provided when creating a NodeConfig.

On loraMesh.py:
python3 loraMesh.py
TypeError: NodeConfig.from_gen_scenario_output() missing 2 required positional arguments: 'tx_power' and 'freq'

On batchSim.py:
python3 batchSim.py
TypeError: NodeConfig.__init__() missing 2 required positional arguments: 'tx_power' and 'freq'

This change adds the missing arguments to both files so NodeConfig objects can be created properly.

All tests pass after changes are made:
python -m unittest discover -s tests
----------------------------------------------------------------------
Ran 31 tests in 2.988s

OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network simulations now consistently apply each scenario’s configured transmit power and frequency to node settings.
  * Improved accuracy of batch and scenario-based simulation results by ensuring complete radio configuration is used for every node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->